### PR TITLE
fix: normalize entrypoint file paths when scan paths are absolute

### DIFF
--- a/examples/js-simple/prune.yaml
+++ b/examples/js-simple/prune.yaml
@@ -19,7 +19,7 @@ scan:
         - coverage/**
 entrypoints:
     files:
-        - src/index.ts
+        - src/index.js
         - src/main.tsx
     patterns:
         - src/pages/**

--- a/internal/lang/js/rules.go
+++ b/internal/lang/js/rules.go
@@ -367,8 +367,43 @@ func buildEntrypointSet(cfg *config.Config) map[string]bool {
 	if cfg == nil {
 		return set
 	}
+
+	scanPaths := cfg.Scan.Paths
+	if len(scanPaths) == 0 {
+		scanPaths = []string{"."}
+	}
+
 	for _, file := range cfg.Entrypoints.Files {
-		set[filepath.ToSlash(file)] = true
+		entry := filepath.ToSlash(file)
+		set[entry] = true
+
+		absEntry, err := filepath.Abs(entry)
+		if err == nil {
+			absEntry = filepath.ToSlash(absEntry)
+			set[absEntry] = true
+		}
+
+		for _, scanPath := range scanPaths {
+			absScanPath, err := filepath.Abs(scanPath)
+			if err != nil {
+				continue
+			}
+			absScanPath = filepath.ToSlash(absScanPath)
+
+			relPath, err := filepath.Rel(absScanPath, absEntry)
+			if err == nil {
+				relPath = filepath.ToSlash(relPath)
+				set[relPath] = true
+			}
+
+			if !strings.Contains(entry, "/") {
+				entryBase := filepath.Base(entry)
+				scanBase := filepath.Base(scanPath)
+				if entryBase == scanBase {
+					set[entry] = true
+				}
+			}
+		}
 	}
 	for _, pattern := range cfg.Entrypoints.Patterns {
 		set[filepath.ToSlash(pattern)] = true


### PR DESCRIPTION
The CLI converts scan paths to absolute paths, but entrypoint paths from the config were not being matched against the file relative paths. Now buildEntrypointSet calculates relative paths from each scan path to properly identify entrypoints.