### PR TITLE
Normalize entrypoint file paths and redesign CLI output format

### DIFF
--- a/examples/js-simple/prune.yaml
+++ b/examples/js-simple/prune.yaml
@@ -19,7 +19,7 @@ scan:
         - coverage/**
 entrypoints:
     files:
-        - src/index.ts
+        - src/index.js
         - src/main.tsx
     patterns:
         - src/pages/**

--- a/internal/cli/e2e_test.go
+++ b/internal/cli/e2e_test.go
@@ -18,14 +18,15 @@ func TestE2EScanOutputsFindings(t *testing.T) {
 	}
 
 	out := string(output)
-	if !strings.Contains(out, "unused_export") {
-		t.Fatalf("expected unused_export in output")
+	// unused.ts is detected as an unused_file, so individual findings are deduplicated.
+	if !strings.Contains(out, "unused file") {
+		t.Fatalf("expected 'unused file' in output, got:\n%s", out)
 	}
-	if !strings.Contains(out, "unused_function") {
-		t.Fatalf("expected unused_function in output")
+	if !strings.Contains(out, "unused function") {
+		t.Fatalf("expected 'unused function' in output, got:\n%s", out)
 	}
-	if !strings.Contains(out, "unused_variable") {
-		t.Fatalf("expected unused_variable in output")
+	if !strings.Contains(out, "unused export") {
+		t.Fatalf("expected 'unused export' in output, got:\n%s", out)
 	}
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -18,6 +18,9 @@ type rootOptions struct {
 	failOnFindings bool
 	stream         bool
 	streamInterval int
+	compact        bool
+	only           string
+	deletable      bool
 }
 
 type stringSlice []string
@@ -70,10 +73,13 @@ Commands:
 
 func parseRootFlags(fs *flag.FlagSet, opts *rootOptions) {
 	fs.StringVar(&opts.configPath, "config", "prune.yaml", "Path to prune config")
-	fs.StringVar(&opts.format, "format", "table", "Output format: table or json")
+	fs.StringVar(&opts.format, "format", "pretty", "Output format: pretty, json, or ndjson")
 	fs.StringVar(&opts.minConfidence, "min-confidence", "safe", "Minimum confidence to report")
 	fs.Var(&opts.paths, "paths", "Paths to scan (repeatable)")
 	fs.BoolVar(&opts.failOnFindings, "fail-on-findings", false, "Exit with error if findings are found")
 	fs.BoolVar(&opts.stream, "stream", false, "Enable streaming mode with partial results")
 	fs.IntVar(&opts.streamInterval, "stream-interval", 250, "Interval in ms between stream flushes")
+	fs.BoolVar(&opts.compact, "compact", false, "Show only summary counts")
+	fs.StringVar(&opts.only, "only", "", "Show only findings with this confidence (safe, review, likely_dead)")
+	fs.BoolVar(&opts.deletable, "deletable", false, "Show only files that are safe to delete")
 }

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -89,7 +89,12 @@ func runScan(ctx context.Context, args []string) error {
 		return nil
 	}
 
-	out, err := report.NewFormatter(opts.format)
+	out, err := report.NewFormatter(opts.format, report.FormatterOptions{
+		Duration:  time.Since(start),
+		Compact:   opts.compact,
+		Only:      opts.only,
+		Deletable: opts.deletable,
+	})
 	if err != nil {
 		return fmt.Errorf("creating formatter: %w", err)
 	}
@@ -107,10 +112,6 @@ func runScan(ctx context.Context, args []string) error {
 
 	if opts.failOnFindings && len(filtered) > 0 {
 		return fmt.Errorf("found %d findings", len(filtered))
-	}
-
-	if opts.format == "table" {
-		fmt.Printf("\nScan finished in %s\n", time.Since(start).Round(time.Millisecond))
 	}
 
 	return nil

--- a/internal/lang/js/rules.go
+++ b/internal/lang/js/rules.go
@@ -276,16 +276,18 @@ func isDefaultExportUsed(file string, data *Collected) bool {
 }
 
 func ruleDeadFeatureFlags(cfg *config.Config, data *Collected) []rules.Finding {
-	if !isRuleEnabled(cfg, "dead_feature_flag") {
+	ruleName := "possible_dynamic_usage"
+	legacyName := "dead_feature_flag"
+	if !isRuleEnabled(cfg, ruleName) && !isRuleEnabled(cfg, legacyName) {
 		return nil
 	}
 
 	findings := []rules.Finding{}
 	if len(data.FeatureFlagRefs) == 0 && len(cfg.FeatureFlags.Patterns) > 0 {
-		confidence := confidenceFor(cfg, "dead_feature_flag", "if_never_referenced", "safe")
+		confidence := confidenceFor(cfg, legacyName, "if_never_referenced", "review")
 		findings = append(findings, rules.Finding{
-			ID:         "dead_feature_flag:patterns",
-			Kind:       "dead_feature_flag",
+			ID:         "possible_dynamic_usage:patterns",
+			Kind:       "possible_dynamic_usage",
 			Confidence: confidence,
 			File:       "",
 			Line:       0,
@@ -299,19 +301,19 @@ func ruleDeadFeatureFlags(cfg *config.Config, data *Collected) []rules.Finding {
 			if data.FeatureFlagRefs[hit.Flag] > 0 {
 				continue
 			}
-			confidence := confidenceFor(cfg, "dead_feature_flag", "if_never_referenced", "safe")
+			confidence := confidenceFor(cfg, legacyName, "if_never_referenced", "review")
 			line := hit.Line
 			if line == 0 {
 				line = 1
 			}
 			findings = append(findings, rules.Finding{
-				ID:         "dead_feature_flag:" + file + ":" + hit.Flag,
-				Kind:       "dead_feature_flag",
+				ID:         "possible_dynamic_usage:" + file + ":" + hit.Flag,
+				Kind:       "possible_dynamic_usage",
 				Confidence: confidence,
 				File:       file,
 				Line:       line,
 				Symbol:     hit.Flag,
-				Reason:     "feature flag never referenced",
+				Reason:     "feature flag patterns detected — verify usage",
 			})
 		}
 	}

--- a/internal/lang/js/rules.go
+++ b/internal/lang/js/rules.go
@@ -367,8 +367,43 @@ func buildEntrypointSet(cfg *config.Config) map[string]bool {
 	if cfg == nil {
 		return set
 	}
+
+	scanPaths := cfg.Scan.Paths
+	if len(scanPaths) == 0 {
+		scanPaths = []string{"."}
+	}
+
 	for _, file := range cfg.Entrypoints.Files {
-		set[filepath.ToSlash(file)] = true
+		entry := filepath.ToSlash(file)
+		set[entry] = true
+
+		absEntry, err := filepath.Abs(entry)
+		if err == nil {
+			absEntry = filepath.ToSlash(absEntry)
+			set[absEntry] = true
+		}
+
+		for _, scanPath := range scanPaths {
+			absScanPath, err := filepath.Abs(scanPath)
+			if err != nil {
+				continue
+			}
+			absScanPath = filepath.ToSlash(absScanPath)
+
+			relPath, err := filepath.Rel(absScanPath, absEntry)
+			if err == nil {
+				relPath = filepath.ToSlash(relPath)
+				set[relPath] = true
+			}
+
+			if !strings.Contains(entry, "/") {
+				entryBase := filepath.Base(entry)
+				scanBase := filepath.Base(scanPath)
+				if entryBase == scanBase {
+					set[entry] = true
+				}
+			}
+		}
 	}
 	for _, pattern := range cfg.Entrypoints.Patterns {
 		set[filepath.ToSlash(pattern)] = true

--- a/internal/report/pretty.go
+++ b/internal/report/pretty.go
@@ -1,0 +1,295 @@
+package report
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"prune/internal/rules"
+)
+
+var confidenceOrder = []string{"safe", "likely_dead", "review"}
+
+var kindLabels = map[string]string{
+	"unused_file":              "unused file",
+	"unused_export":            "unused export",
+	"unused_function":          "unused function",
+	"unused_variable":          "unused variable",
+	"suspicious_dynamic_usage": "suspicious dynamic usage",
+	"dead_feature_flag":        "dead feature flag",
+}
+
+var confidenceLabels = map[string]string{
+	"safe":        "SAFE",
+	"likely_dead": "LIKELY DEAD",
+	"review":      "REVIEW",
+}
+
+const (
+	colorReset  = "\033[0m"
+	colorGreen  = "\033[32m"
+	colorYellow = "\033[33m"
+	colorRed    = "\033[31m"
+	colorDim    = "\033[2m"
+	colorBold   = "\033[1m"
+	colorCyan   = "\033[36m"
+)
+
+var confidenceColors = map[string]string{
+	"safe":        colorGreen,
+	"likely_dead": colorRed,
+	"review":      colorYellow,
+}
+
+var confidenceIcons = map[string]string{
+	"safe":        "✔",
+	"likely_dead": "✖",
+	"review":      "⚠",
+}
+
+type prettyFormatter struct {
+	opts FormatterOptions
+}
+
+func (f prettyFormatter) Format(findings []rules.Finding) ([]byte, error) {
+	useColor := supportsColor()
+	var b strings.Builder
+
+	if len(findings) == 0 {
+		b.WriteString(f.header(0, useColor))
+		b.WriteString("\n")
+		msg := "✨ No dead code found!\n"
+		if useColor {
+			msg = colorGreen + msg + colorReset
+		}
+		b.WriteString(msg)
+		return []byte(b.String()), nil
+	}
+
+	if f.opts.Only != "" {
+		filtered := make([]rules.Finding, 0, len(findings))
+		for _, finding := range findings {
+			if strings.EqualFold(finding.Confidence, f.opts.Only) {
+				filtered = append(filtered, finding)
+			}
+		}
+		findings = filtered
+	}
+
+	if f.opts.Deletable {
+		filtered := make([]rules.Finding, 0, len(findings))
+		for _, finding := range findings {
+			if finding.Kind == "unused_file" && finding.Confidence == "safe" {
+				filtered = append(filtered, finding)
+			}
+		}
+		findings = filtered
+	}
+
+	findings = deduplicateUnusedFiles(findings)
+
+	b.WriteString(f.header(len(findings), useColor))
+	b.WriteString("\n")
+	if f.opts.Compact {
+		b.WriteString(f.summary(findings, useColor))
+		return []byte(b.String()), nil
+	}
+
+	grouped := groupByConfidence(findings)
+
+	for _, confidence := range confidenceOrder {
+		fileGroups, ok := grouped[confidence]
+		if !ok || len(fileGroups) == 0 {
+			continue
+		}
+
+		total := 0
+		for _, ff := range fileGroups {
+			total += len(ff)
+		}
+
+		label := confidenceLabels[confidence]
+		icon := confidenceIcons[confidence]
+		color := ""
+		reset := ""
+		if useColor {
+			color = confidenceColors[confidence]
+			reset = colorReset
+		}
+
+		b.WriteString(fmt.Sprintf("%s%s %s%s (%d)\n", color, icon, label, reset, total))
+		b.WriteString("\n")
+
+		files := make([]string, 0, len(fileGroups))
+		for file := range fileGroups {
+			files = append(files, file)
+		}
+		sort.Strings(files)
+
+		for _, file := range files {
+			ff := fileGroups[file]
+			sort.Slice(ff, func(i, j int) bool {
+				return ff[i].Kind < ff[j].Kind
+			})
+
+			displayFile := file
+			if displayFile == "" {
+				displayFile = "(no file)"
+			}
+			if useColor {
+				b.WriteString(fmt.Sprintf("  %s%s%s\n", colorCyan, displayFile, colorReset))
+			} else {
+				b.WriteString(fmt.Sprintf("  %s\n", displayFile))
+			}
+
+			for _, finding := range ff {
+				kindLabel := kindLabels[finding.Kind]
+				if kindLabel == "" {
+					kindLabel = finding.Kind
+				}
+
+				detail := kindLabel
+				if finding.Symbol != "" {
+					detail = fmt.Sprintf("%s: %s", kindLabel, finding.Symbol)
+				}
+
+				if useColor {
+					b.WriteString(fmt.Sprintf("  %s└─%s %s\n", colorDim, colorReset, detail))
+				} else {
+					b.WriteString(fmt.Sprintf("  └─ %s\n", detail))
+				}
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	b.WriteString(f.summary(findings, useColor))
+	return []byte(b.String()), nil
+}
+
+func (f prettyFormatter) header(count int, useColor bool) string {
+	var b strings.Builder
+	ver := "v" + version
+	if useColor {
+		b.WriteString(fmt.Sprintf("%s%sPrune %s%s\n", colorBold, colorCyan, ver, colorReset))
+	} else {
+		b.WriteString(fmt.Sprintf("Prune %s\n", ver))
+	}
+
+	noun := "issues"
+	if count == 1 {
+		noun = "issue"
+	}
+	dur := f.opts.Duration.Round(time.Millisecond)
+	b.WriteString(fmt.Sprintf("Found %d %s in %s\n", count, noun, dur))
+	return b.String()
+}
+
+func (f prettyFormatter) summary(findings []rules.Finding, useColor bool) string {
+	var b strings.Builder
+
+	typeCounts := map[string]int{}
+	confCounts := map[string]int{}
+	for _, finding := range findings {
+		typeCounts[finding.Kind]++
+		confCounts[finding.Confidence]++
+	}
+
+	separator := "─────────────────────────────────\n"
+	if useColor {
+		b.WriteString(colorDim + separator + colorReset)
+	} else {
+		b.WriteString(separator)
+	}
+
+	b.WriteString("Summary\n")
+	b.WriteString("\n")
+
+	typeOrder := []struct {
+		key   string
+		label string
+	}{
+		{"unused_file", "Files"},
+		{"unused_export", "Exports"},
+		{"unused_function", "Functions"},
+		{"unused_variable", "Variables"},
+	}
+	for _, t := range typeOrder {
+		if c, ok := typeCounts[t.key]; ok && c > 0 {
+			b.WriteString(fmt.Sprintf("  %-12s %d\n", t.label, c))
+		}
+	}
+
+	b.WriteString("\n")
+
+	for _, confidence := range confidenceOrder {
+		c := confCounts[confidence]
+		if c == 0 {
+			continue
+		}
+		label := confidenceLabels[confidence]
+		color := ""
+		reset := ""
+		if useColor {
+			color = confidenceColors[confidence]
+			reset = colorReset
+		}
+		b.WriteString(fmt.Sprintf("  %s%-12s%s %d\n", color, label, reset, c))
+	}
+
+	b.WriteString("\n")
+	dur := f.opts.Duration.Round(time.Millisecond)
+	if useColor {
+		b.WriteString(fmt.Sprintf("%sDone in %s%s\n", colorDim, dur, colorReset))
+	} else {
+		b.WriteString(fmt.Sprintf("Done in %s\n", dur))
+	}
+
+	return b.String()
+}
+
+func deduplicateUnusedFiles(findings []rules.Finding) []rules.Finding {
+	unusedFiles := map[string]bool{}
+	for _, f := range findings {
+		if f.Kind == "unused_file" {
+			unusedFiles[f.File] = true
+		}
+	}
+	if len(unusedFiles) == 0 {
+		return findings
+	}
+
+	result := make([]rules.Finding, 0, len(findings))
+	for _, f := range findings {
+		if unusedFiles[f.File] && f.Kind != "unused_file" {
+			continue
+		}
+		result = append(result, f)
+	}
+	return result
+}
+
+func groupByConfidence(findings []rules.Finding) map[string]map[string][]rules.Finding {
+	result := map[string]map[string][]rules.Finding{}
+	for _, f := range findings {
+		conf := f.Confidence
+		if result[conf] == nil {
+			result[conf] = map[string][]rules.Finding{}
+		}
+		result[conf][f.File] = append(result[conf][f.File], f)
+	}
+	return result
+}
+
+func supportsColor() bool {
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		return false
+	}
+	fi, err := os.Stdout.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}

--- a/internal/report/pretty.go
+++ b/internal/report/pretty.go
@@ -18,7 +18,7 @@ var kindLabels = map[string]string{
 	"unused_function":          "unused function",
 	"unused_variable":          "unused variable",
 	"suspicious_dynamic_usage": "suspicious dynamic usage",
-	"dead_feature_flag":        "dead feature flag",
+	"possible_dynamic_usage":   "possible dynamic usage",
 }
 
 var confidenceLabels = map[string]string{
@@ -49,8 +49,27 @@ var confidenceIcons = map[string]string{
 	"review":      "⚠",
 }
 
+var classificationRules = map[string]string{
+	"unused_file":              "safe",
+	"unused_export":            "safe",
+	"unused_function":          "likely_dead",
+	"possible_dynamic_usage":   "review",
+	"suspicious_dynamic_usage": "review",
+}
+
 type prettyFormatter struct {
 	opts FormatterOptions
+}
+
+func normalizeClassification(findings []rules.Finding) []rules.Finding {
+	result := make([]rules.Finding, len(findings))
+	copy(result, findings)
+	for i := range result {
+		if override, ok := classificationRules[result[i].Kind]; ok {
+			result[i].Confidence = override
+		}
+	}
+	return result
 }
 
 func (f prettyFormatter) Format(findings []rules.Finding) ([]byte, error) {
@@ -89,6 +108,7 @@ func (f prettyFormatter) Format(findings []rules.Finding) ([]byte, error) {
 	}
 
 	findings = deduplicateUnusedFiles(findings)
+	findings = normalizeClassification(findings)
 
 	b.WriteString(f.header(len(findings), useColor))
 	b.WriteString("\n")
@@ -172,18 +192,17 @@ func (f prettyFormatter) Format(findings []rules.Finding) ([]byte, error) {
 func (f prettyFormatter) header(count int, useColor bool) string {
 	var b strings.Builder
 	ver := "v" + version
-	if useColor {
-		b.WriteString(fmt.Sprintf("%s%sPrune %s%s\n", colorBold, colorCyan, ver, colorReset))
-	} else {
-		b.WriteString(fmt.Sprintf("Prune %s\n", ver))
-	}
-
 	noun := "issues"
 	if count == 1 {
 		noun = "issue"
 	}
 	dur := f.opts.Duration.Round(time.Millisecond)
-	b.WriteString(fmt.Sprintf("Found %d %s in %s\n", count, noun, dur))
+
+	if useColor {
+		b.WriteString(fmt.Sprintf("%s%sPrune %s%s — %d %s found in %s\n", colorBold, colorCyan, ver, colorReset, count, noun, dur))
+	} else {
+		b.WriteString(fmt.Sprintf("Prune %s — %d %s found in %s\n", ver, count, noun, dur))
+	}
 	return b.String()
 }
 
@@ -215,6 +234,8 @@ func (f prettyFormatter) summary(findings []rules.Finding, useColor bool) string
 		{"unused_export", "Exports"},
 		{"unused_function", "Functions"},
 		{"unused_variable", "Variables"},
+		{"possible_dynamic_usage", "Dynamic"},
+		{"suspicious_dynamic_usage", "Suspicious"},
 	}
 	for _, t := range typeOrder {
 		if c, ok := typeCounts[t.key]; ok && c > 0 {
@@ -240,6 +261,9 @@ func (f prettyFormatter) summary(findings []rules.Finding, useColor bool) string
 	}
 
 	b.WriteString("\n")
+	b.WriteString(fmt.Sprintf("  Total        %d\n", len(findings)))
+	b.WriteString("\n")
+
 	dur := f.opts.Duration.Round(time.Millisecond)
 	if useColor {
 		b.WriteString(fmt.Sprintf("%sDone in %s%s\n", colorDim, dur, colorReset))

--- a/internal/report/pretty_test.go
+++ b/internal/report/pretty_test.go
@@ -31,16 +31,50 @@ func TestDeduplicateUnusedFiles(t *testing.T) {
 func TestGroupByConfidence(t *testing.T) {
 	findings := []rules.Finding{
 		{Confidence: "safe", File: "a.js", Kind: "unused_export"},
-		{Confidence: "safe", File: "b.js", Kind: "unused_function"},
+		{Confidence: "likely_dead", File: "b.js", Kind: "unused_function"},
 		{Confidence: "review", File: "c.js", Kind: "suspicious_dynamic_usage"},
 	}
 
 	grouped := groupByConfidence(findings)
-	if len(grouped["safe"]) != 2 {
-		t.Fatalf("expected 2 files in safe group, got %d", len(grouped["safe"]))
+	if len(grouped["safe"]) != 1 {
+		t.Fatalf("expected 1 file in safe group, got %d", len(grouped["safe"]))
+	}
+	if len(grouped["likely_dead"]) != 1 {
+		t.Fatalf("expected 1 file in likely_dead group, got %d", len(grouped["likely_dead"]))
 	}
 	if len(grouped["review"]) != 1 {
 		t.Fatalf("expected 1 file in review group, got %d", len(grouped["review"]))
+	}
+}
+
+func TestNormalizeClassification(t *testing.T) {
+	findings := []rules.Finding{
+		{Kind: "unused_file", Confidence: "review"},
+		{Kind: "unused_export", Confidence: "review"},
+		{Kind: "unused_function", Confidence: "safe"},
+		{Kind: "possible_dynamic_usage", Confidence: "safe"},
+		{Kind: "suspicious_dynamic_usage", Confidence: "safe"},
+		{Kind: "unused_variable", Confidence: "safe"},
+	}
+
+	result := normalizeClassification(findings)
+
+	tests := []struct {
+		kind     string
+		expected string
+	}{
+		{"unused_file", "safe"},
+		{"unused_export", "safe"},
+		{"unused_function", "likely_dead"},
+		{"possible_dynamic_usage", "review"},
+		{"suspicious_dynamic_usage", "review"},
+		{"unused_variable", "safe"}, // unused_variable retains original
+	}
+
+	for i, tt := range tests {
+		if result[i].Confidence != tt.expected {
+			t.Fatalf("kind %s: expected confidence %q, got %q", tt.kind, tt.expected, result[i].Confidence)
+		}
 	}
 }
 
@@ -55,7 +89,7 @@ func TestPrettyCompactMode(t *testing.T) {
 
 	findings := []rules.Finding{
 		{Confidence: "safe", Kind: "unused_export", File: "a.js", Symbol: "x"},
-		{Confidence: "safe", Kind: "unused_function", File: "b.js", Symbol: "y"},
+		{Confidence: "likely_dead", Kind: "unused_function", File: "b.js", Symbol: "y"},
 		{Confidence: "review", Kind: "suspicious_dynamic_usage", File: "c.js", Symbol: "z"},
 	}
 
@@ -146,6 +180,7 @@ func TestPrettyGroupingOrder(t *testing.T) {
 	findings := []rules.Finding{
 		{Confidence: "review", Kind: "suspicious_dynamic_usage", File: "z.js", Symbol: "a"},
 		{Confidence: "safe", Kind: "unused_export", File: "b.js", Symbol: "x"},
+		// unused_function will be normalized to likely_dead
 		{Confidence: "safe", Kind: "unused_function", File: "a.js", Symbol: "y"},
 	}
 
@@ -156,21 +191,104 @@ func TestPrettyGroupingOrder(t *testing.T) {
 
 	output := string(data)
 	safeIdx := strings.Index(output, "SAFE")
+	likelyDeadIdx := strings.Index(output, "LIKELY DEAD")
 	reviewIdx := strings.Index(output, "REVIEW")
-	if safeIdx == -1 || reviewIdx == -1 {
-		t.Fatalf("expected both SAFE and REVIEW sections, got: %s", output)
+	if safeIdx == -1 || likelyDeadIdx == -1 || reviewIdx == -1 {
+		t.Fatalf("expected SAFE, LIKELY DEAD, and REVIEW sections, got: %s", output)
 	}
-	if safeIdx > reviewIdx {
-		t.Fatalf("SAFE should appear before REVIEW, got: %s", output)
+	if safeIdx > likelyDeadIdx {
+		t.Fatalf("SAFE should appear before LIKELY DEAD, got: %s", output)
+	}
+	if likelyDeadIdx > reviewIdx {
+		t.Fatalf("LIKELY DEAD should appear before REVIEW, got: %s", output)
+	}
+}
+
+func TestPrettyHeaderFormat(t *testing.T) {
+	formatter, err := NewFormatter("pretty", FormatterOptions{
+		Duration: 42 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Inside SAFE section, files should be sorted alphabetically.
-	aIdx := strings.Index(output, "a.js")
-	bIdx := strings.Index(output, "b.js")
-	if aIdx == -1 || bIdx == -1 {
-		t.Fatalf("expected both a.js and b.js, got: %s", output)
+	findings := []rules.Finding{
+		{Confidence: "safe", Kind: "unused_export", File: "a.js", Symbol: "x"},
+		{Confidence: "safe", Kind: "unused_export", File: "b.js", Symbol: "y"},
 	}
-	if aIdx > bIdx {
-		t.Fatalf("a.js should appear before b.js, got: %s", output)
+
+	data, err := formatter.Format(findings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(data)
+	// Should contain the new single-line header format with em dash
+	if !strings.Contains(output, "—") {
+		t.Fatalf("expected em dash in header, got: %s", output)
+	}
+	if !strings.Contains(output, "2 issues found in") {
+		t.Fatalf("expected '2 issues found in' in header, got: %s", output)
+	}
+}
+
+func TestPrettySummaryIncludesTotal(t *testing.T) {
+	formatter, err := NewFormatter("pretty", FormatterOptions{
+		Duration: 5 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	findings := []rules.Finding{
+		{Confidence: "safe", Kind: "unused_export", File: "a.js", Symbol: "x"},
+		{Confidence: "safe", Kind: "unused_file", File: "b.js"},
+		{Confidence: "review", Kind: "suspicious_dynamic_usage", File: "c.js", Symbol: "eval"},
+	}
+
+	data, err := formatter.Format(findings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, "Total") {
+		t.Fatalf("expected Total in summary, got: %s", output)
+	}
+	if !strings.Contains(output, "Files") {
+		t.Fatalf("expected Files count in summary, got: %s", output)
+	}
+	if !strings.Contains(output, "Exports") {
+		t.Fatalf("expected Exports count in summary, got: %s", output)
+	}
+}
+
+func TestPossibleDynamicUsageIsReview(t *testing.T) {
+	formatter, err := NewFormatter("pretty", FormatterOptions{
+		Duration: 5 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	findings := []rules.Finding{
+		{Confidence: "safe", Kind: "possible_dynamic_usage", File: "a.js", Symbol: "console.log"},
+	}
+
+	data, err := formatter.Format(findings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(data)
+	// possible_dynamic_usage must be normalized to REVIEW, never SAFE
+	if strings.Contains(output, "SAFE") {
+		t.Fatalf("possible_dynamic_usage should NOT be in SAFE, got: %s", output)
+	}
+	if !strings.Contains(output, "REVIEW") {
+		t.Fatalf("expected possible_dynamic_usage in REVIEW section, got: %s", output)
+	}
+	if !strings.Contains(output, "possible dynamic usage: console.log") {
+		t.Fatalf("expected label 'possible dynamic usage: console.log', got: %s", output)
 	}
 }

--- a/internal/report/pretty_test.go
+++ b/internal/report/pretty_test.go
@@ -1,0 +1,176 @@
+package report
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"prune/internal/rules"
+)
+
+func TestDeduplicateUnusedFiles(t *testing.T) {
+	findings := []rules.Finding{
+		{Kind: "unused_file", File: "src/dead.js", Confidence: "safe"},
+		{Kind: "unused_export", File: "src/dead.js", Confidence: "safe", Symbol: "foo"},
+		{Kind: "unused_function", File: "src/dead.js", Confidence: "safe", Symbol: "bar"},
+		{Kind: "unused_export", File: "src/alive.js", Confidence: "review", Symbol: "baz"},
+	}
+
+	result := deduplicateUnusedFiles(findings)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 findings after dedup, got %d", len(result))
+	}
+
+	for _, f := range result {
+		if f.File == "src/dead.js" && f.Kind != "unused_file" {
+			t.Fatalf("expected only unused_file for dead.js, got %s", f.Kind)
+		}
+	}
+}
+
+func TestGroupByConfidence(t *testing.T) {
+	findings := []rules.Finding{
+		{Confidence: "safe", File: "a.js", Kind: "unused_export"},
+		{Confidence: "safe", File: "b.js", Kind: "unused_function"},
+		{Confidence: "review", File: "c.js", Kind: "suspicious_dynamic_usage"},
+	}
+
+	grouped := groupByConfidence(findings)
+	if len(grouped["safe"]) != 2 {
+		t.Fatalf("expected 2 files in safe group, got %d", len(grouped["safe"]))
+	}
+	if len(grouped["review"]) != 1 {
+		t.Fatalf("expected 1 file in review group, got %d", len(grouped["review"]))
+	}
+}
+
+func TestPrettyCompactMode(t *testing.T) {
+	formatter, err := NewFormatter("pretty", FormatterOptions{
+		Duration: 5 * time.Millisecond,
+		Compact:  true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	findings := []rules.Finding{
+		{Confidence: "safe", Kind: "unused_export", File: "a.js", Symbol: "x"},
+		{Confidence: "safe", Kind: "unused_function", File: "b.js", Symbol: "y"},
+		{Confidence: "review", Kind: "suspicious_dynamic_usage", File: "c.js", Symbol: "z"},
+	}
+
+	data, err := formatter.Format(findings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(data)
+	// Compact mode should include the summary but NOT the individual file details.
+	if !strings.Contains(output, "Summary") {
+		t.Fatalf("expected Summary section, got: %s", output)
+	}
+	// Should NOT have tree markers in compact output.
+	if strings.Contains(output, "└─") {
+		t.Fatalf("compact mode should not show tree details, got: %s", output)
+	}
+}
+
+func TestPrettyOnlyFilter(t *testing.T) {
+	formatter, err := NewFormatter("pretty", FormatterOptions{
+		Duration: 5 * time.Millisecond,
+		Only:     "safe",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	findings := []rules.Finding{
+		{Confidence: "safe", Kind: "unused_export", File: "a.js", Symbol: "x"},
+		{Confidence: "review", Kind: "suspicious_dynamic_usage", File: "c.js", Symbol: "z"},
+	}
+
+	data, err := formatter.Format(findings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, "a.js") {
+		t.Fatalf("expected safe finding a.js in output, got: %s", output)
+	}
+	if strings.Contains(output, "c.js") {
+		t.Fatalf("review finding c.js should be filtered out, got: %s", output)
+	}
+}
+
+func TestPrettyDeletableFilter(t *testing.T) {
+	formatter, err := NewFormatter("pretty", FormatterOptions{
+		Duration:  5 * time.Millisecond,
+		Deletable: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	findings := []rules.Finding{
+		{Confidence: "safe", Kind: "unused_file", File: "src/dead.js"},
+		{Confidence: "safe", Kind: "unused_export", File: "src/alive.js", Symbol: "x"},
+		{Confidence: "review", Kind: "unused_file", File: "src/maybe.js"},
+	}
+
+	data, err := formatter.Format(findings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, "src/dead.js") {
+		t.Fatalf("expected safe unused_file in output, got: %s", output)
+	}
+	if strings.Contains(output, "src/alive.js") {
+		t.Fatalf("non-unused-file findings should be filtered, got: %s", output)
+	}
+	if strings.Contains(output, "src/maybe.js") {
+		t.Fatalf("non-safe unused_file should be filtered, got: %s", output)
+	}
+}
+
+func TestPrettyGroupingOrder(t *testing.T) {
+	formatter, err := NewFormatter("pretty", FormatterOptions{
+		Duration: 5 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	findings := []rules.Finding{
+		{Confidence: "review", Kind: "suspicious_dynamic_usage", File: "z.js", Symbol: "a"},
+		{Confidence: "safe", Kind: "unused_export", File: "b.js", Symbol: "x"},
+		{Confidence: "safe", Kind: "unused_function", File: "a.js", Symbol: "y"},
+	}
+
+	data, err := formatter.Format(findings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	output := string(data)
+	safeIdx := strings.Index(output, "SAFE")
+	reviewIdx := strings.Index(output, "REVIEW")
+	if safeIdx == -1 || reviewIdx == -1 {
+		t.Fatalf("expected both SAFE and REVIEW sections, got: %s", output)
+	}
+	if safeIdx > reviewIdx {
+		t.Fatalf("SAFE should appear before REVIEW, got: %s", output)
+	}
+
+	// Inside SAFE section, files should be sorted alphabetically.
+	aIdx := strings.Index(output, "a.js")
+	bIdx := strings.Index(output, "b.js")
+	if aIdx == -1 || bIdx == -1 {
+		t.Fatalf("expected both a.js and b.js, got: %s", output)
+	}
+	if aIdx > bIdx {
+		t.Fatalf("a.js should appear before b.js, got: %s", output)
+	}
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -5,22 +5,37 @@ import (
 	"fmt"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"prune/internal/rules"
 )
+
+var version = "0.0.3"
+
+type FormatterOptions struct {
+	Duration  time.Duration
+	Compact   bool
+	Only      string
+	Deletable bool
+}
 
 type Formatter interface {
 	Format([]rules.Finding) ([]byte, error)
 }
 
-func NewFormatter(format string) (Formatter, error) {
+func NewFormatter(format string, opts ...FormatterOptions) (Formatter, error) {
+	o := FormatterOptions{}
+	if len(opts) > 0 {
+		o = opts[0]
+	}
+
 	switch strings.ToLower(format) {
 	case "json":
 		return jsonFormatter{}, nil
 	case "ndjson":
 		return ndjsonFormatter{}, nil
-	case "table":
-		return tableFormatter{}, nil
+	case "table", "pretty":
+		return prettyFormatter{opts: o}, nil
 	default:
 		return nil, fmt.Errorf("unknown format: %q", format)
 	}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -12,8 +12,11 @@ func TestNewFormatter(t *testing.T) {
 	if f, err := NewFormatter("json"); err != nil || f == nil {
 		t.Fatalf("expected json formatter, got err: %v", err)
 	}
+	if f, err := NewFormatter("pretty"); err != nil || f == nil {
+		t.Fatalf("expected pretty formatter, got err: %v", err)
+	}
 	if f, err := NewFormatter("table"); err != nil || f == nil {
-		t.Fatalf("expected table formatter, got err: %v", err)
+		t.Fatalf("expected table (alias for pretty) formatter, got err: %v", err)
 	}
 	if f, err := NewFormatter("unknown"); err == nil || f != nil {
 		t.Fatalf("expected error for unknown formatter")
@@ -68,47 +71,54 @@ func TestJSONFormatter(t *testing.T) {
 	}
 }
 
-func TestTableFormatter(t *testing.T) {
-	formatter, err := NewFormatter("table")
+func TestPrettyFormatterNoFindings(t *testing.T) {
+	formatter, err := NewFormatter("pretty")
 	if err != nil || formatter == nil {
-		t.Fatalf("missing table formatter, err: %v", err)
+		t.Fatalf("missing pretty formatter, err: %v", err)
 	}
 
 	data, err := formatter.Format(nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if string(data) != "✨ No dead code found!\n" {
-		t.Fatalf("unexpected no-findings output")
+	if !strings.Contains(string(data), "No dead code found") {
+		t.Fatalf("unexpected no-findings output: %s", string(data))
+	}
+}
+
+func TestPrettyFormatterWithFindings(t *testing.T) {
+	formatter, err := NewFormatter("pretty")
+	if err != nil || formatter == nil {
+		t.Fatalf("missing pretty formatter, err: %v", err)
 	}
 
-	findings := []rules.Finding{{Confidence: "safe", Kind: "unused", File: "a.js", Line: 2, Symbol: "x", Reason: "r"}}
-	data, err = formatter.Format(findings)
+	findings := []rules.Finding{{Confidence: "safe", Kind: "unused_export", File: "a.js", Line: 2, Symbol: "x", Reason: "r"}}
+	data, err := formatter.Format(findings)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	output := string(data)
-	if !strings.Contains(output, "CONFIDENCE") || !strings.Contains(output, "REASON") {
-		t.Fatalf("missing header")
-	}
 	if !strings.Contains(output, "SAFE") {
-		t.Fatalf("missing row status")
+		t.Fatalf("missing SAFE section")
 	}
 	if !strings.Contains(output, "a.js") {
-		t.Fatalf("missing row file")
+		t.Fatalf("missing file path")
+	}
+	if !strings.Contains(output, "unused export: x") {
+		t.Fatalf("missing finding detail, got: %s", output)
 	}
 }
 
-func TestTableFormatterMissingFile(t *testing.T) {
-	formatter, err := NewFormatter("table")
+func TestPrettyFormatterMissingFile(t *testing.T) {
+	formatter, err := NewFormatter("pretty")
 	if err != nil || formatter == nil {
-		t.Fatalf("missing table formatter, err: %v", err)
+		t.Fatalf("missing pretty formatter, err: %v", err)
 	}
 	data, err := formatter.Format([]rules.Finding{{Confidence: "safe", Kind: "dead_feature_flag"}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(string(data), "SAFE") {
-		t.Fatalf("expected placeholder for missing file")
+		t.Fatalf("expected SAFE section in output")
 	}
 }

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -114,11 +114,11 @@ func TestPrettyFormatterMissingFile(t *testing.T) {
 	if err != nil || formatter == nil {
 		t.Fatalf("missing pretty formatter, err: %v", err)
 	}
-	data, err := formatter.Format([]rules.Finding{{Confidence: "safe", Kind: "dead_feature_flag"}})
+	data, err := formatter.Format([]rules.Finding{{Confidence: "review", Kind: "possible_dynamic_usage"}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(string(data), "SAFE") {
-		t.Fatalf("expected SAFE section in output")
+	if !strings.Contains(string(data), "REVIEW") {
+		t.Fatalf("expected REVIEW section in output")
 	}
 }

--- a/internal/rules/rules.go
+++ b/internal/rules/rules.go
@@ -22,7 +22,7 @@ func All() []RuleDefinition {
 		{ID: "unused_variable", Description: "Variable declared but never used"},
 		{ID: "unused_export", Description: "Exported symbol never imported"},
 		{ID: "unused_file", Description: "File never imported or referenced"},
-		{ID: "dead_feature_flag", Description: "Feature flag with dead code"},
+		{ID: "possible_dynamic_usage", Description: "Possible dynamic usage detected via pattern match"},
 		{ID: "suspicious_dynamic_usage", Description: "Dynamic usage that blocks certainty"},
 	}
 }

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -24,7 +24,7 @@ func TestAllRulesIncludesExpected(t *testing.T) {
 		"unused_variable":          false,
 		"unused_export":            false,
 		"unused_file":              false,
-		"dead_feature_flag":        false,
+		"possible_dynamic_usage":   false,
 		"suspicious_dynamic_usage": false,
 	}
 


### PR DESCRIPTION
This pull request introduces a new, user-friendly "pretty" output format for scan reports, adds several new CLI options to customize output, and improves the classification and deduplication of findings. The changes also update the handling of feature flag findings and include comprehensive tests for the new functionality.