### PR TITLE
docs: update docs

### DIFF
--- a/docs/content/docs/cli-reference.mdx
+++ b/docs/content/docs/cli-reference.mdx
@@ -77,7 +77,7 @@ prune scan [flags]
 | Flag | Type | Default | Description |
 |---|---|---|---|
 | `--config` | string | `prune.yaml` | Path to the Prune configuration file |
-| `--format` | string | `table` | Output format: `table`, `json`, or `ndjson` |
+| `--format` | string | `pretty` | Output format: `pretty`, `json`, `ndjson`, or `table` (alias for `pretty`) |
 | `--min-confidence` | string | `safe` | Minimum confidence level to include in output: `safe`, `likely_dead`, or `review` |
 | `--paths` | string (repeatable) | _(from config)_ | Override scan paths. Can be specified multiple times |
 | `--fail-on-findings` | bool | `false` | Exit with a non-zero status code if any findings match the confidence filter |
@@ -111,7 +111,7 @@ prune scan --stream --stream-interval 100
 
 **Notes on streaming:**
 
-When `--stream` is enabled and `--format` is `json`, the format is automatically promoted to `ndjson`. The `table` format is not supported in streaming mode — only `ndjson` produces streamed output; for other formats, the stream flag enables batched collection but output is still printed once after completion.
+When `--stream` is enabled and `--format` is `json`, the format is automatically promoted to `ndjson`. The `pretty` and `table` formats are not supported in streaming mode — only `ndjson` produces streamed output; for other formats, the stream flag enables batched collection but output is still printed once after completion.
 
 ---
 
@@ -133,7 +133,7 @@ unused_function             Function declared but never used
 unused_variable             Variable declared but never used
 unused_export               Exported symbol never imported
 unused_file                 File never imported or referenced
-dead_feature_flag           Feature flag with dead code
+possible_dynamic_usage      Possible dynamic usage detected via pattern match
 suspicious_dynamic_usage    Dynamic usage that blocks certainty
 ```
 

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -72,7 +72,7 @@ rules:
     confidence:
       default: safe
       if_entrypoint: review
-  dead_feature_flag:
+  possible_dynamic_usage:
     enabled: true
     confidence:
       if_never_referenced: safe
@@ -88,7 +88,7 @@ rules:
       default: review
 
 report:
-  format: table
+  format: pretty
   min_confidence: safe
   include_evidence: true
 ```
@@ -204,7 +204,7 @@ entrypoints:
 **Type:** list of regular expression strings  
 **Default:** `["flags\\.[A-Z0-9_]+", "featureFlags\\.[A-Za-z0-9_]+"]`
 
-Regular expressions used to detect feature flag references in source code. The `dead_feature_flag` rule uses these patterns to find flag accesses in the AST (via `member_expression` and `subscript_expression` nodes) and report flags that are never referenced.
+Regular expressions used to detect feature flag references in source code. The `possible_dynamic_usage` rule uses these patterns to find flag accesses in the AST (via `member_expression` and `subscript_expression` nodes) and report flags that are never referenced.
 
 ```yaml
 feature_flags:
@@ -281,13 +281,13 @@ rules:
       if_entrypoint: review
 ```
 
-#### `rules.dead_feature_flag`
+#### `rules.possible_dynamic_usage`
 
 Detects feature flag references matching `feature_flags.patterns` that are never referenced in the codebase. If no flags are found at all matching the patterns, a single finding is emitted.
 
 ```yaml
 rules:
-  dead_feature_flag:
+  possible_dynamic_usage:
     enabled: true
     confidence:
       if_never_referenced: safe
@@ -320,8 +320,8 @@ These fields set defaults for the output, but CLI flags (`--format`, `--min-conf
 #### `report.format`
 
 **Type:** string  
-**Default:** `table`  
-**Accepted values:** `table`, `json`, `ndjson`
+**Default:** `pretty`  
+**Accepted values:** `pretty`, `json`, `ndjson`, `table` (alias for `pretty`)
 
 Default output format for `prune scan`.
 

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -22,7 +22,7 @@ Prune traces the dependency graph starting from your configured entrypoints and 
 | `unused_export` | An exported symbol (function, class, const) that is never imported |
 | `unused_function` | A function declared in a file but never referenced |
 | `unused_variable` | A variable declared in a file but never referenced |
-| `dead_feature_flag` | A feature flag expression matching configured patterns that is never referenced |
+| `possible_dynamic_usage` | A possible dynamic usage detected via pattern match (e.g. feature flags) |
 | `suspicious_dynamic_usage` | A call to `eval`, `Function`, `require`, or `import()` that blocks static certainty |
 
 Each finding is assigned a **confidence level** (`safe`, `likely_dead`, or `review`) based on context, and these levels are configurable per rule in `prune.yaml`.

--- a/docs/content/docs/output-format.mdx
+++ b/docs/content/docs/output-format.mdx
@@ -1,10 +1,10 @@
 ---
 title: Output Format
-description: Describes the three output formats — table, JSON, and NDJSON — and the Finding data structure.
+description: Describes the available output formats — pretty (default), json, and ndjson — and the Finding data structure.
 icon: FileText
 ---
 
-Prune supports three output formats, selected via `--format` on the CLI or `report.format` in `prune.yaml`.
+Prune supports three primary output formats, selected via `--format` on the CLI or `report.format` in `prune.yaml`.
 
 ---
 
@@ -25,45 +25,72 @@ Every finding has the following fields, regardless of format:
 
 ---
 
-## Table Format
+## Pretty Format (Default)
 
-The default format. Outputs a tab-aligned table to stdout using fixed-width columns.
+The default format. Outputs a human-friendly tree structure grouped by file and confidence level.
 
 ```bash
 prune scan
-prune scan --format table
+prune scan --format pretty
+prune scan --format table  # alias for pretty
 ```
 
 **Example output:**
 
-```
-CONFIDENCE    KIND                       FILE                              LINE   SYMBOL              REASON
-SAFE          unused_file                src/utils/legacy.ts               1      legacy.ts           file is not referenced by any import
-SAFE          unused_export              src/components/Button.tsx         42     OldButtonVariant    exported symbol is never imported
-LIKELY_DEAD   unused_function            src/lib/helpers.ts                18     formatDeprecated    function declared but never referenced
-REVIEW        suspicious_dynamic_usage   src/loader.ts                     1      require             dynamic usage may hide references
+```bash
+Prune v0.1.0-beta.1 — 4 issues found in 340ms
 
-Scan finished in 340ms
+✔ SAFE (2)
+
+  src/utils/legacy.ts
+  └─ unused file: legacy.ts
+
+  src/components/Button.tsx
+  └─ unused export: OldButtonVariant
+
+⚠ LIKELY DEAD (1)
+
+  src/lib/helpers.ts
+  └─ unused function: formatDeprecated
+
+⚠ REVIEW (1)
+
+  src/loader.ts
+  └─ suspicious dynamic usage: require
+
+─────────────────────────────────
+Summary
+
+  Files        1
+  Exports      1
+  Functions    1
+  Dynamic      1
+
+  SAFE         2
+  LIKELY DEAD  1
+  REVIEW       1
+
+  Total        4
+
+Done in 340ms
 ```
 
 When no findings match the confidence filter:
 
-```
+```bash
 ✨ No dead code found!
 
-Scan finished in 280ms
+Done in 280ms
 ```
 
-**Column details:**
+**Output details:**
 
-- `CONFIDENCE`: Uppercase confidence level
-- `KIND`: Rule identifier
-- `FILE`: Relative path to the file, or `-` if not file-specific
-- `LINE`: Declaration line number
-- `SYMBOL`: Identifier or file basename
-- `REASON`: Short description from the rule
+- **Grouping**: Findings are grouped first by **Confidence Level** (`SAFE`, `LIKELY DEAD`, `REVIEW`) and then by **File Path**.
+- **Icons**: Uses `✔` for SAFE findings and `⚠` for LIKELY DEAD and REVIEW levels.
+- **Summary**: Provides an aggregated count of findings by type (Files, Exports, Functions, Dynamic) and by confidence level.
+- **Duration**: The total execution time is displayed at the top and bottom.
 
-The scan duration line is printed only in table format, not in JSON or NDJSON mode.
+The `pretty` format is designed for developer readability. For automation or large-scale data processing, use `json` or `ndjson`.
 
 ---
 

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -67,16 +67,44 @@ prune scan
 
 Prune reads `prune.yaml` from the current directory, walks the declared scan paths, parses every matching file, and prints findings to stdout.
 
-**Example output (table format):**
+**Example output (`pretty` format):**
 
-```
-CONFIDENCE    KIND              FILE                        LINE   SYMBOL              REASON
-SAFE          unused_file       src/utils/legacy.ts         1      legacy.ts           file is not referenced by any import
-SAFE          unused_export     src/components/Button.tsx   42     OldButtonVariant    exported symbol is never imported
-LIKELY_DEAD   unused_function   src/lib/helpers.ts          18     formatDeprecated    function declared but never referenced
-REVIEW        suspicious_dynamic_usage  src/loader.ts       1      require             dynamic usage may hide references
+```bash
+Prune v0.1.0-beta.1 — 4 issues found in 340ms
 
-Scan finished in 340ms
+✔ SAFE (2)
+
+  src/utils/legacy.ts
+  └─ unused file: legacy.ts
+
+  src/components/Button.tsx
+  └─ unused export: OldButtonVariant
+
+⚠ LIKELY DEAD (1)
+
+  src/lib/helpers.ts
+  └─ unused function: formatDeprecated
+
+⚠ REVIEW (1)
+
+  src/loader.ts
+  └─ suspicious dynamic usage: require
+
+─────────────────────────────────
+Summary
+
+  Files        1
+  Exports      1
+  Functions    1
+  Dynamic      1
+
+  SAFE         2
+  LIKELY DEAD  1
+  REVIEW       1
+
+  Total        4
+
+Done in 340ms
 ```
 
 If no dead code is found:

--- a/docs/src/app/(home)/_components/code-example.tsx
+++ b/docs/src/app/(home)/_components/code-example.tsx
@@ -4,17 +4,17 @@ import CodeBlock from "../../../components/code-block";
 
 export default function CodeExample() {
   return (
-    <Section className="flex-col gap-6 max-w-4xl mx-auto py-12 md:py-16 border-y border-border bg-muted/30">
+    <Section className="flex-col gap-8 max-w-4xl mx-auto py-16 sm:py-24 border-y border-border bg-muted/30">
       <div className="flex flex-col gap-4">
-        <h2 className="text-4xl font-bold tracking-tight">Simple configuration. Powerful results.</h2>
+        <h2 className="text-3xl sm:text-4xl font-bold tracking-tight">Simple configuration. Powerful results.</h2>
         
-        <p className="text-lg text-muted-foreground mt-6 flex items-center gap-2">
-          <Terminal size={18} /> Initialize your project with a single command:
+        <p className="text-base sm:text-lg text-muted-foreground mt-8 flex items-center gap-2">
+          <Terminal size={18} className="shrink-0" /> Initialize your project with a single command:
         </p>
         <CodeBlock code="prune init" lang="bash" />
         
-        <p className="text-lg text-muted-foreground mt-6">
-          Your <code className="bg-background px-1.5 py-0.5 rounded border border-border text-sm">prune.yaml</code> keeps things explicit:
+        <p className="text-base sm:text-lg text-muted-foreground mt-8">
+          Your <code className="bg-background px-1.5 py-0.5 rounded border border-border text-xs sm:text-sm">prune.yaml</code> keeps things explicit:
         </p>
         <CodeBlock 
           filename="prune.yaml" 
@@ -38,8 +38,8 @@ rules:
   orphaned_file: enabled`}
         />
         
-        <p className="text-lg text-muted-foreground mt-6 flex items-center gap-2">
-          <Terminal size={18} /> Run the scan and clear the noise:
+        <p className="text-base sm:text-lg text-muted-foreground mt-8 flex items-center gap-2">
+          <Terminal size={18} className="shrink-0" /> Run the scan and clear the noise:
         </p>
         <CodeBlock code="prune scan --fail-on-findings" lang="bash" />
       </div>

--- a/docs/src/app/(home)/_components/cta.tsx
+++ b/docs/src/app/(home)/_components/cta.tsx
@@ -5,38 +5,38 @@ import { Download, Star, BookOpen, Heart } from "lucide-react";
 
 export default function CallToAction() {
   return (
-    <Section className="flex-col gap-8 max-w-4xl mx-auto py-12 md:py-16 items-center text-center">
-      <h2 className="text-5xl font-bold tracking-tight">Find what you can delete in 60 seconds</h2>
-      <p className="text-2xl text-muted-foreground">
+    <Section className="flex-col gap-10 max-w-4xl mx-auto py-20 sm:py-32 items-center text-center">
+      <h2 className="text-4xl sm:text-5xl font-bold tracking-tight leading-tight px-4 sm:px-0">Find what you can delete in 60 seconds</h2>
+      <p className="text-xl sm:text-2xl text-muted-foreground max-w-2xl px-4 sm:px-0">
         Install Prune and see how much code you can remove today.
       </p>
-      <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mt-4 w-full">
-        <Link href="https://github.com/carlosedujs/prune/releases/latest" className="w-full sm:w-auto">
-          <Button size="lg" className="w-full sm:w-auto">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-8 w-full max-w-xl px-6 sm:px-0">
+        <Link href="https://github.com/carlosedujs/prune/releases/latest" className="w-full">
+          <Button size="lg" className="w-full h-12 text-base">
             <Download className="mr-2 h-5 w-5" />
             Install for your OS
           </Button>
         </Link>
-        <Link href="https://github.com/carlosedujs/prune" className="w-full sm:w-auto">
-          <Button variant="outline" size="lg" className="w-full sm:w-auto">
+        <Link href="https://github.com/carlosedujs/prune" className="w-full">
+          <Button variant="outline" size="lg" className="w-full h-12 text-base">
             <Star className="mr-2 h-5 w-5" />
             Star on GitHub
           </Button>
         </Link>
-        <Link href="/docs" className="w-full sm:w-auto">
-          <Button variant="outline" size="lg" className="w-full sm:w-auto">
+        <Link href="/docs" className="w-full">
+          <Button variant="outline" size="lg" className="w-full h-12 text-base">
             <BookOpen className="mr-2 h-5 w-5" />
             Read the Docs
           </Button>
         </Link>
-        <Link href="https://github.com/sponsors/CarlosEduJs" className="w-full sm:w-auto">
-          <Button variant="outline" size="lg" className="w-full sm:w-auto">
+        <Link href="https://github.com/sponsors/CarlosEduJs" className="w-full">
+          <Button variant="outline" size="lg" className="w-full h-12 text-base">
             <Heart className="mr-2 h-5 w-5" />
             Sponsor
           </Button>
         </Link>
       </div>
-      <p className="text-base text-muted-foreground mt-4 font-medium">
+      <p className="text-sm sm:text-base text-muted-foreground mt-8 font-medium px-4 sm:px-0 italic opacity-80">
         Join early and help shape the fastest code-pruning engine being built.
       </p>
     </Section>

--- a/docs/src/app/(home)/_components/features.tsx
+++ b/docs/src/app/(home)/_components/features.tsx
@@ -2,32 +2,32 @@ import Section from "./section";
 
 export default function Features() {
   return (
-    <Section className="flex-col gap-8 max-w-4xl mx-auto py-12 md:py-16">
-      <h2 className="text-4xl font-bold tracking-tight">Key Features</h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-6">
+    <Section className="flex-col gap-10 max-w-4xl mx-auto py-16 sm:py-24">
+      <h2 className="text-3xl sm:text-4xl font-bold tracking-tight text-center sm:text-left">Key Features</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-12 gap-y-10">
         <div className="flex flex-col gap-3">
           <h3 className="font-semibold text-xl">Runs Anywhere</h3>
-          <p className="text-muted-foreground leading-relaxed">Cross-platform support (Linux, macOS, Windows) with a single binary.</p>
+          <p className="text-muted-foreground leading-relaxed text-sm sm:text-base text-justify sm:text-left">Cross-platform support (Linux, macOS, Windows) with a single binary.</p>
         </div>
         <div className="flex flex-col gap-3">
           <h3 className="font-semibold text-xl">CI/CD Ready</h3>
-          <p className="text-muted-foreground leading-relaxed">Drop it into your pipeline and fail builds when dead code is detected.</p>
+          <p className="text-muted-foreground leading-relaxed text-sm sm:text-base text-justify sm:text-left">Drop it into your pipeline and fail builds when dead code is detected.</p>
         </div>
         <div className="flex flex-col gap-3">
           <h3 className="font-semibold text-xl">Confidence Scoring</h3>
-          <p className="text-muted-foreground leading-relaxed">Distinguishes between "safe to delete" and "review required" cases.</p>
+          <p className="text-muted-foreground leading-relaxed text-sm sm:text-base text-justify sm:text-left">Distinguishes between "safe to delete" and "review required" cases.</p>
         </div>
         <div className="flex flex-col gap-3">
           <h3 className="font-semibold text-xl">Tree-sitter Powered</h3>
-          <p className="text-muted-foreground leading-relaxed">High-performance parsing without the overhead of a full compiler.</p>
+          <p className="text-muted-foreground leading-relaxed text-sm sm:text-base text-justify sm:text-left">High-performance parsing without the overhead of a full compiler.</p>
         </div>
         <div className="flex flex-col gap-3">
           <h3 className="font-semibold text-xl">Real-time Streaming</h3>
-          <p className="text-muted-foreground leading-relaxed">Use <code className="bg-muted px-1.5 py-0.5 rounded border border-border text-xs">--stream</code> to see findings as they are discovered.</p>
+          <p className="text-muted-foreground leading-relaxed text-sm sm:text-base text-justify sm:text-left">Use <code className="bg-muted px-1.5 py-0.5 rounded border border-border text-[10px] sm:text-xs">--stream</code> to see findings as they are discovered.</p>
         </div>
         <div className="flex flex-col gap-3">
           <h3 className="font-semibold text-xl">Machine Readable</h3>
-          <p className="text-muted-foreground leading-relaxed">Output in <code className="bg-muted px-1.5 py-0.5 rounded border border-border text-xs">json</code> or <code className="bg-muted px-1.5 py-0.5 rounded border border-border text-xs">ndjson</code> for integrations and custom tooling.</p>
+          <p className="text-muted-foreground leading-relaxed text-sm sm:text-base text-justify sm:text-left">Output in <code className="bg-muted px-1.5 py-0.5 rounded border border-border text-[10px] sm:text-xs">json</code> or <code className="bg-muted px-1.5 py-0.5 rounded border border-border text-[10px] sm:text-xs">ndjson</code> for integrations and custom tooling.</p>
         </div>
       </div>
     </Section>

--- a/docs/src/app/(home)/_components/hero.tsx
+++ b/docs/src/app/(home)/_components/hero.tsx
@@ -7,28 +7,32 @@ import { SiReadthedocs } from "react-icons/si";
 
 export default function Hero() {
   return (
-    <Section className="py-0 h-[90vh] items-center w-fit mx-auto">
-      <div className="flex flex-col max-w-2xl gap-6">
-        <h1 className="text-6xl font-bold">Zero out the dead weight in your codebase</h1>
-        <p className="text-xl font-light">Find and remove unreachable code, orphaned files, and unused exports in JS/TS projects, all this in just a few seconds. Works on any OS. Fits right into your CI.</p>
-        <div className="flex items-center gap-4">
-          <Link href="/docs">
-            <Button size={"lg"}>
-              <SiReadthedocs />
-              Get Started
-            </Button>
-          </Link>
-          <Link href="https://github.com/carlosedujs/prune/releases/latest">
-            <Button variant={"outline"} size={"lg"} className="w-fit">
-              <Download />
-              Install Prune
-            </Button>
-          </Link>
-          <div className="flex items-center gap-2">
-            <h2 className="text-xs">Available on</h2>
-            <FaWindows />
-            <FaLinux />
-            <FaApple />
+    <Section className="py-20 min-h-[80vh] flex-col justify-center items-center w-full mx-auto">
+      <div className="flex flex-col max-w-2xl gap-8 text-center sm:text-left items-center sm:items-start">
+        <h1 className="text-4xl sm:text-6xl font-bold leading-tight">Zero out the dead weight in your codebase</h1>
+        <p className="text-lg sm:text-xl font-light leading-relaxed">Find and remove unreachable code, orphaned files, and unused exports in JS/TS projects, all this in just a few seconds. Works on any OS. Fits right into your CI.</p>
+        <div className="flex flex-col sm:flex-row items-center gap-6 w-full">
+          <div className="flex flex-col sm:flex-row items-center gap-4 w-full sm:w-auto">
+            <Link href="/docs" className="w-full sm:w-auto">
+              <Button size={"lg"} className="w-full sm:w-auto">
+                <SiReadthedocs />
+                Get Started
+              </Button>
+            </Link>
+            <Link href="https://github.com/carlosedujs/prune/releases/latest" className="w-full sm:w-auto">
+              <Button variant={"outline"} size={"lg"} className="w-full sm:w-auto">
+                <Download />
+                Install Prune
+              </Button>
+            </Link>
+          </div>
+          <div className="flex items-center gap-3 py-2 px-4 rounded-full bg-accent">
+            <h2 className="text-xs font-light text-muted-foreground">Available on</h2>
+            <div className="flex items-center gap-3">
+              <FaWindows className="text-lg" />
+              <FaLinux className="text-lg" />
+              <FaApple className="text-lg" />
+            </div>
           </div>
         </div>
       </div>

--- a/docs/src/app/(home)/_components/how-it-works.tsx
+++ b/docs/src/app/(home)/_components/how-it-works.tsx
@@ -3,11 +3,11 @@ import { CheckCircle2 } from "lucide-react";
 
 export default function HowItWorks() {
   return (
-    <Section className="flex-col gap-8 max-w-4xl mx-auto py-12 md:py-16">
+    <Section className="flex-col gap-10 max-w-4xl mx-auto py-16 sm:py-24">
       <div className="flex flex-col gap-4">
-        <h2 className="text-4xl font-bold tracking-tight">How It Works</h2>
+        <h2 className="text-3xl sm:text-4xl font-bold tracking-tight">How It Works</h2>
       </div>
-      <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-10">
         {[
           {
             title: "Define Entrypoints",
@@ -26,20 +26,20 @@ export default function HowItWorks() {
             desc: "Get a clear list of what can be safely removed or reviewed."
           }
         ].map((item, i) => (
-          <div key={i} className="flex gap-6 items-start">
-            <div className="flex items-center justify-center min-w-10 min-h-10 rounded-full border border-border bg-muted text-foreground font-semibold text-lg">
+          <div key={i} className="flex flex-col sm:flex-row gap-4 sm:gap-8 items-start">
+            <div className="flex items-center justify-center min-w-10 min-h-10 sm:min-w-12 sm:min-h-12 rounded-full border border-border bg-muted text-foreground font-semibold text-lg sm:text-xl">
               {i + 1}
             </div>
             <div className="flex flex-col gap-2 pt-1">
-              <h3 className="font-semibold text-2xl">{item.title}</h3>
-              <p className="text-lg text-muted-foreground">{item.desc}</p>
+              <h3 className="font-semibold text-xl sm:text-2xl">{item.title}</h3>
+              <p className="text-base sm:text-lg text-muted-foreground mt-1 sm:mt-0">{item.desc}</p>
             </div>
           </div>
         ))}
       </div>
-      <div className="pt-8 border-t border-border mt-4 flex items-center gap-3">
-        <CheckCircle2 className="text-muted-foreground" />
-        <p className="text-xl font-medium tracking-tight">Run it locally or in CI — same behavior, same results.</p>
+      <div className="pt-8 border-t border-border mt-6 flex flex-col sm:flex-row items-center sm:items-start gap-4 text-center sm:text-left">
+        <CheckCircle2 className="text-muted-foreground shrink-0 hidden sm:block" />
+        <p className="text-lg sm:text-xl font-medium tracking-tight">Run it locally or in CI — same behavior, same results.</p>
       </div>
     </Section>
   );

--- a/docs/src/app/(home)/_components/navbar.tsx
+++ b/docs/src/app/(home)/_components/navbar.tsx
@@ -23,13 +23,13 @@ export default function Navbar() {
   return (
     <div className={cn(
       "fixed top-0 left-0 right-0 z-50 flex justify-center w-full pointer-events-none transition-all duration-500 ease-out",
-      isScrolled ? "pt-4 sm:pt-6" : "pt-0"
+      isScrolled ? "pt-2 sm:pt-6" : "pt-0"
     )}>
       <header className={cn(
         "flex items-center justify-between pointer-events-auto transition-all duration-500 ease-out border",
         isScrolled 
-          ? "w-[95%] max-w-3xl px-6 py-3 bg-background/80 backdrop-blur-md rounded-full shadow-sm border-border" 
-          : "w-full max-w-full px-12 py-6 bg-transparent border-transparent rounded-none"
+          ? "w-[92%] sm:w-[95%] max-w-3xl px-4 sm:px-6 py-2 sm:py-3 bg-background/80 backdrop-blur-md rounded-full shadow-sm border-border" 
+          : "w-full max-w-full px-6 sm:px-12 py-4 sm:py-6 bg-transparent border-transparent rounded-none"
       )}>
         <h1 className={cn(
           "font-bold transition-all duration-500",

--- a/docs/src/app/(home)/_components/problem.tsx
+++ b/docs/src/app/(home)/_components/problem.tsx
@@ -2,29 +2,29 @@ import Section from "./section";
 
 export default function Problem() {
   return (
-    <Section className="flex-col gap-8 max-w-4xl mx-auto py-12 md:pt-16 my-12">
-      <div className="flex flex-col gap-4">
-        <h2 className="text-4xl font-bold tracking-tight">Your codebase is growing, but is it actually doing anything?</h2>
-        <p className="text-xl text-muted-foreground leading-relaxed">
+    <Section className="flex-col gap-10 max-w-4xl mx-auto py-16 sm:py-24">
+      <div className="flex flex-col gap-4 text-center sm:text-left">
+        <h2 className="text-3xl sm:text-4xl font-bold tracking-tight leading-tight">Your codebase is growing, but is it actually doing anything?</h2>
+        <p className="text-lg sm:text-xl text-muted-foreground leading-relaxed max-w-3xl">
           As projects evolve, they accumulate technical debt in the form of "zombie" code. Files are moved, features are deprecated, and exports are left hanging. Standard linters catch unused variables, but they miss the bigger picture:
         </p>
       </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 sm:gap-12">
         <div className="flex flex-col gap-3">
-          <h3 className="font-semibold text-xl">Orphaned Files</h3>
-          <p className="text-muted-foreground leading-relaxed">Entire components and modules that are never imported but still bloat your bundle and slow down your build.</p>
+          <h3 className="font-semibold text-xl sm:text-2xl">Orphaned Files</h3>
+          <p className="text-muted-foreground leading-relaxed text-sm sm:text-base">Entire components and modules that are never imported but still bloat your bundle and slow down your build.</p>
         </div>
         <div className="flex flex-col gap-3">
-          <h3 className="font-semibold text-xl">Dead Exports</h3>
-          <p className="text-muted-foreground leading-relaxed">Library functions and components that are exported "just in case" but have zero consumers.</p>
+          <h3 className="font-semibold text-xl sm:text-2xl">Dead Exports</h3>
+          <p className="text-muted-foreground leading-relaxed text-sm sm:text-base">Library functions and components that are exported "just in case" but have zero consumers.</p>
         </div>
         <div className="flex flex-col gap-3">
-          <h3 className="font-semibold text-xl">Shadow Dependencies</h3>
-          <p className="text-muted-foreground leading-relaxed">Code referenced in tests or documentation but completely unreachable from your production entrypoints.</p>
+          <h3 className="font-semibold text-xl sm:text-2xl">Shadow Dependencies</h3>
+          <p className="text-muted-foreground leading-relaxed text-sm sm:text-base">Code referenced in tests or documentation but completely unreachable from your production entrypoints.</p>
         </div>
         <div className="flex flex-col gap-3">
-          <h3 className="font-semibold text-xl">Analysis Paralysis</h3>
-          <p className="text-muted-foreground leading-relaxed">Static analysis tools are often too slow to run on every commit or too noisy to trust.</p>
+          <h3 className="font-semibold text-xl sm:text-2xl">Analysis Paralysis</h3>
+          <p className="text-muted-foreground leading-relaxed text-sm sm:text-base">Static analysis tools are often too slow to run on every commit or too noisy to trust.</p>
         </div>
       </div>
       <div className="pt-4 border-t border-border mt-4">

--- a/docs/src/app/(home)/_components/section.tsx
+++ b/docs/src/app/(home)/_components/section.tsx
@@ -9,7 +9,7 @@ interface SectionProps {
 
 export default function Section({ children, className }: SectionProps) {
   return (
-    <section className={cn("flex px-12 py-6 w-full", className)}>
+    <section className={cn("flex px-6 py-8 sm:px-12 sm:py-12 w-full", className)}>
       {children}
     </section>
   );

--- a/docs/src/app/(home)/_components/solution.tsx
+++ b/docs/src/app/(home)/_components/solution.tsx
@@ -2,12 +2,12 @@ import Section from "./section";
 
 export default function Solution() {
   return (
-    <Section className="flex-col gap-6 max-w-4xl mx-auto py-12 md:py-16 border-y border-border bg-muted/30">
-      <h2 className="text-4xl font-bold tracking-tight">Precision-engineered code pruning</h2>
-      <p className="text-xl text-muted-foreground leading-relaxed">
+    <Section className="flex-col gap-6 max-w-4xl mx-auto py-16 sm:py-24 border-y border-border bg-muted/30">
+      <h2 className="text-3xl sm:text-4xl font-bold tracking-tight leading-tight">Precision-engineered code pruning</h2>
+      <p className="text-lg sm:text-xl text-muted-foreground leading-relaxed">
         Prune builds a complete dependency graph of your application starting from your actual entrypoints. If a file, function, or export isn't reachable from the root, it's flagged as dead code.
       </p>
-      <p className="text-xl text-muted-foreground leading-relaxed">
+      <p className="text-lg sm:text-xl text-muted-foreground leading-relaxed">
         Built in Go and powered by Tree-sitter, Prune is fast enough to run as a pre-commit hook or as a blocking gate in your CI/CD pipeline. No more manual hunting—just a clean, leaner codebase.
       </p>
     </Section>

--- a/docs/src/app/(home)/_components/why-its-different.tsx
+++ b/docs/src/app/(home)/_components/why-its-different.tsx
@@ -2,23 +2,23 @@ import Section from "./section";
 
 export default function WhyItsDifferent() {
   return (
-    <Section className="flex-col gap-6 max-w-4xl mx-auto py-12 md:py-16 border-y border-border bg-muted/30">
-      <h2 className="text-4xl font-bold tracking-tight">Built for speed, not just compliance</h2>
-      <p className="text-xl text-muted-foreground leading-relaxed">
+    <Section className="flex-col gap-6 max-w-4xl mx-auto py-16 sm:py-24 border-y border-border bg-muted/30">
+      <h2 className="text-3xl sm:text-4xl font-bold tracking-tight leading-tight">Built for speed, not just compliance</h2>
+      <p className="text-lg sm:text-xl text-muted-foreground leading-relaxed">
         Most tools either slow you down or give you results you can't trust. Prune does neither.
       </p>
-      <ul className="flex flex-col gap-6 mt-4 text-lg">
-        <li className="flex items-start gap-3">
-          <div className="mt-1 w-2 h-2 rounded-full bg-primary shrink-0" />
-          <p className="text-muted-foreground"><strong className="text-foreground font-semibold">Faster than TSC:</strong> Focused on structural reachability without full type-checking overhead.</p>
+      <ul className="flex flex-col gap-6 mt-6">
+        <li className="flex items-start gap-4">
+          <div className="mt-2 w-2 h-2 rounded-full bg-primary shrink-0" />
+          <p className="text-muted-foreground text-base sm:text-lg"><strong className="text-foreground font-semibold">Faster than TSC:</strong> Focused on structural reachability without full type-checking overhead.</p>
         </li>
-        <li className="flex items-start gap-3">
-          <div className="mt-1 w-2 h-2 rounded-full bg-primary shrink-0" />
-          <p className="text-muted-foreground"><strong className="text-foreground font-semibold">Deterministic:</strong> No black-box heuristics—Prune follows your code exactly.</p>
+        <li className="flex items-start gap-4">
+          <div className="mt-2 w-2 h-2 rounded-full bg-primary shrink-0" />
+          <p className="text-muted-foreground text-base sm:text-lg"><strong className="text-foreground font-semibold">Deterministic:</strong> No black-box heuristics—Prune follows your code exactly.</p>
         </li>
-        <li className="flex items-start gap-3">
-          <div className="mt-1 w-2 h-2 rounded-full bg-primary shrink-0" />
-          <p className="text-muted-foreground"><strong className="text-foreground font-semibold">Non-Intrusive:</strong> Works alongside your existing tools without requiring project changes.</p>
+        <li className="flex items-start gap-4">
+          <div className="mt-2 w-2 h-2 rounded-full bg-primary shrink-0" />
+          <p className="text-muted-foreground text-base sm:text-lg"><strong className="text-foreground font-semibold">Non-Intrusive:</strong> Works alongside your existing tools without requiring project changes.</p>
         </li>
       </ul>
     </Section>


### PR DESCRIPTION
This pull request updates the documentation to clarify and improve the description of output formats, rule naming, and UI consistency for Prune. The most significant changes are the renaming of the `dead_feature_flag` rule to `possible_dynamic_usage`, the introduction of the new default output format `pretty` (with `table` as an alias), and various improvements to example outputs and UI text for better readability and clarity.