### PR TITLE
release: v0.2.0 beta.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Flags:
 - `--fail-on-findings`: Exit with a non-zero status code if problems are detected.
 - `--stream`: Enable streaming mode for partial results in real-time.
 - `--stream-interval`: Interval in ms between stream flushes (default: 250ms).
+- `--compact`: Show only summary counts.
+- `--only`: Show only findings with this confidence.
+- `--deletable`: Show only files that are safe to delete.
 
 
 Pretty Output
@@ -121,6 +124,43 @@ Summary
   Total        11
 
 Done in 9ms
+```
+
+### JSON Output
+
+For automation, use JSON format with structured output:
+
+```bash
+prune scan --format json
+```
+
+Output includes summary, findings, and metadata:
+
+```json
+{
+  "summary": {
+    "files": 3,
+    "issues": 12,
+    "safe": 7,
+    "review": 5
+  },
+  "findings": [
+    {
+      "id": "unused_file:src/utils/legacy.ts",
+      "kind": "unused_file",
+      "confidence": "safe",
+      "file": "src/utils/legacy.ts",
+      "line": 1,
+      "symbol": "legacy.ts",
+      "reason": "file is not referenced by any import"
+    }
+    // ... more findings
+  ],
+  "metadata": {
+    "entrypoints": ["src/main.ts", "src/pages/**"],
+    "scan_time_ms": 9
+  }
+}
 ```
 
 ### Streaming Mode

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Prune identifies unreachable code by building a dependency graph from defined en
     - Suspicious dynamic code usage (e.g., `eval`, `Function`).
 - Human-friendly CLI output format grouped by file (`pretty`).
 - Machine-readable output (JSON, NDJSON) for automation.
+- **Path alias resolution** for TypeScript aliases like `@/` and `~/`.
 - **Streaming mode** for partial results in real-time.
 - CI/CD integration via exit codes and finding thresholds.
 - Cross-platform support (Linux, macOS, Windows).
@@ -155,10 +156,20 @@ prune rules
 Configuration is managed via `prune.yaml`.
 
 ```yaml
-version: 1
+version: 2
 project:
   name: my-project
   language: js-ts
+
+ts_config:
+  enabled: true
+  baseUrl: .
+  paths:
+    "@/*":
+      - src/*
+    "~/*":
+      - src/components/*
+
 scan:
   paths:
     - src
@@ -238,6 +249,7 @@ The `--fail-on-findings` flag ensures that the pipeline exits with a non-zero st
 - Support is currently restricted to JavaScript and TypeScript ecosystems.
 - Dynamic imports or class property access via strings may result in false positives (marked as `REVIEW`).
 - Large codebases with circular dependencies may require higher memory allocation during Graph traversal.
+- Scoped alias patterns like `@scope/*` are not supported.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Prune
 
 > [!NOTE]
-> **Prune is currently in Beta (v0.1.0-beta.1).** It is under active development, and features, CLI flags, or output formats may change before the stable release.
+> **Prune is currently in Beta (v0.2.0-beta.1).** It is under active development, and features, CLI flags, or output formats may change before the stable release.
 
 Static analysis tool designed to identify dead code in JavaScript and TypeScript projects (for now...).
 
@@ -87,7 +87,7 @@ Flags:
 Pretty Output
 
 ```bash
-Prune v0.1.0-beta.1 — 11 issues found in 9ms
+Prune 0.2.0-beta.1 — 11 issues found in 9ms
 
 ✔ SAFE (1)
 

--- a/docs/content/docs/ci-cd-integration.mdx
+++ b/docs/content/docs/ci-cd-integration.mdx
@@ -98,6 +98,28 @@ To run Prune and log findings without blocking the pipeline:
 
 In CI, JSON or NDJSON output is more useful than the table format for downstream tools:
 
+// [!code ++]
+```bash
+# Count total safe findings (updated for new JSON structure)
+prune scan --format json | jq '.findings | map(select(.confidence == "safe")) | length'
+
+# List all orphaned files
+prune scan --format json | jq '.findings[] | select(.kind == "unused_file") | .file'
+
+# Fail if more than 10 safe findings
+COUNT=$(prune scan --format json | jq '.findings | map(select(.confidence == "safe")) | length')
+if [ "$COUNT" -gt 10 ]; then
+  echo "Too many dead code findings: $COUNT"
+  exit 1
+fi
+```
+
+<Callout type="info">
+The new JSON format wraps findings in a root object with `summary` and `metadata`. Update any jq filters to access `.findings` first.
+</Callout>
+// [!code --]
+
+// [!code highlight]
 ```bash
 # Count total safe findings
 prune scan --format json | jq 'map(select(.confidence == "safe")) | length'
@@ -112,6 +134,7 @@ if [ "$COUNT" -gt 10 ]; then
   exit 1
 fi
 ```
+// [!code focus]
 
 ---
 

--- a/docs/content/docs/ci-cd-integration.mdx
+++ b/docs/content/docs/ci-cd-integration.mdx
@@ -142,6 +142,18 @@ version: 2
 project:
   name: my-app
   language: js-ts
+
+// [!code ++]
+ts_config:
+  enabled: true
+  baseUrl: .
+  paths:
+    "@/*":
+      - src/*
+    "~/*":
+      - src/components/*
+// [!code --]
+
 scan:
   paths:
     - src

--- a/docs/content/docs/ci-cd-integration.mdx
+++ b/docs/content/docs/ci-cd-integration.mdx
@@ -138,7 +138,7 @@ A production configuration for a TypeScript project using Prune in CI:
 **`prune.yaml`:**
 
 ```yaml
-version: 1
+version: 2
 project:
   name: my-app
   language: js-ts

--- a/docs/content/docs/cli-reference.mdx
+++ b/docs/content/docs/cli-reference.mdx
@@ -27,7 +27,7 @@ prune version
 **Output:**
 
 ```
-prune version  0.1.0-beta.1
+prune version  0.2.0-beta.1
 ```
 
 No flags are accepted by this command.

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -6,9 +6,7 @@ icon: Settings
 
 Prune is configured through a YAML file, by default named `prune.yaml` in the current directory. You can generate a starting config with `prune init`, or write one from scratch using the reference below.
 
-The `version` field is required and must be `2`. Prune will refuse to run if `version` is missing or zero.
-
----
+The `version` field is required and must be `2` (or `1` for legacy configs). Prune will refuse to run if `version` is missing or zero.
 
 ## Full Schema
 
@@ -27,6 +25,93 @@ ts_config:
       - src/*
     "~/*":
       - src/components/*
+
+scan:
+  paths:
+    - src
+  include:
+    - '**/*.ts'
+    - '**/*.tsx'
+    - '**/*.js'
+    - '**/*.jsx'
+  exclude:
+    - node_modules/**
+    - dist/**
+    - build/**
+    - .next/**
+    - out/**
+    - coverage/**
+  stream:
+    enabled: false
+    interval_ms: 250
+
+entrypoints:
+  files:
+    - src/index.ts
+  patterns:
+    - src/pages/**
+    - src/routes/**
+
+feature_flags:
+  patterns:
+    - 'flags\.[A-Z0-9_]+'
+    - 'featureFlags\.[A-Za-z0-9_]+'
+
+rules:
+  unused_function:
+    enabled: true
+    confidence:
+      default: likely_dead
+      if_dynamic_usage: review
+  unused_variable:
+    enabled: true
+    confidence:
+      default: safe
+      if_exported: likely_dead
+      if_dynamic_usage: review
+  unused_export:
+    enabled: true
+    confidence:
+      if_not_imported: safe
+      if_entrypoint: review
+  unused_file:
+    enabled: true
+    confidence:
+      default: safe
+      if_entrypoint: review
+  possible_dynamic_usage:
+    enabled: true
+    confidence:
+      if_never_referenced: safe
+      if_dynamic_reference: review
+  suspicious_dynamic_usage:
+    enabled: true
+    patterns:
+      - eval
+      - Function
+      - require
+      - 'import('
+    confidence:
+      default: review
+
+report:
+  format: pretty
+  min_confidence: safe
+  include_evidence: true
+```
+
+## Migration from v1
+
+If you're upgrading from config version `1`, the only change needed is bumping the version number:
+
+```yaml
+// [!code --]
+version: 1
+// [!code ++]
+version: 2
+```
+
+Version `2` adds support for path aliases via `ts_config`.Configs using version `1` will continue to work — Prune only requires `version >= 1`.
 
 scan:
   paths:

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -6,18 +6,27 @@ icon: Settings
 
 Prune is configured through a YAML file, by default named `prune.yaml` in the current directory. You can generate a starting config with `prune init`, or write one from scratch using the reference below.
 
-The `version` field is required and must be `1`. Prune will refuse to run if `version` is missing or zero.
+The `version` field is required and must be `2`. Prune will refuse to run if `version` is missing or zero.
 
 ---
 
 ## Full Schema
 
 ```yaml
-version: 1
+version: 2
 
 project:
   name: my-project
   language: js-ts
+
+ts_config:
+  enabled: false
+  baseUrl: .
+  paths:
+    "@/*":
+      - src/*
+    "~/*":
+      - src/components/*
 
 scan:
   paths:
@@ -339,3 +348,45 @@ The minimum confidence level for findings to be included in output. Findings bel
 **Default:** `true`
 
 Reserved for future use. Currently accepted in the config schema but not used in output formatting.
+
+---
+
+### `ts_config`
+
+Configures module resolution for path aliases (e.g., `@/utils`, `~/components`). Mirrors TypeScript's `tsconfig.json` `paths` and `baseUrl` options.
+
+#### `ts_config.enabled`
+
+**Type:** boolean  
+**Default:** `false`
+
+Enable or disable path alias resolution. When disabled (or not specified), all aliases are treated as external imports.
+
+#### `ts_config.baseUrl`
+
+**Type:** string  
+**Default:** `"."`
+
+The base directory for resolving non-relative module paths. Corresponds to `compilerOptions.baseUrl` in TypeScript.
+
+#### `ts_config.paths`
+
+**Type:** map of string to list of strings  
+**Default:** `{}`
+
+A map of alias patterns to their resolved paths. Uses glob-like pattern matching where `*` matches any string.
+
+```yaml
+ts_config:
+  enabled: true
+  baseUrl: .
+  paths:
+    "@/*":        # @/utils/helper → src/utils/helper
+      - src/*
+    "~/*":       # ~/components/Button → src/components/Button
+      - src/components/*
+    "@shared/*":
+      - packages/shared/*
+```
+
+The first path in each mapping list is used for resolution. If the resolved file is not found, the import is marked with `review` confidence.

--- a/docs/content/docs/configuration.mdx
+++ b/docs/content/docs/configuration.mdx
@@ -196,7 +196,13 @@ report:
 **Type:** integer  
 **Required:** yes
 
-Schema version. Must be `1`. Prune will return an error if this field is absent or set to `0`.
+// [!code --]
+Schema version. Must be `1`.
+// [!code ++]
+Schema version. Must be `2` (or `1` for legacy configs).
+// [!code focus]
+
+Prune will return an error if this field is absent or set to `0`.
 
 ---
 

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -57,5 +57,5 @@ prune version
 Expected output:
 
 ```
-prune version  0.1.0-beta.1
+prune version  0.2.0-beta.1
 ```

--- a/docs/content/docs/limitations.mdx
+++ b/docs/content/docs/limitations.mdx
@@ -36,32 +36,32 @@ Prune has no way to determine which files are actually loaded at runtime. Files 
 
 ## Ignored Import Patterns
 
-Only **relative imports** (starting with `./` or `../`) and **configured aliases** are resolved to files in the project. Non-relative imports are treated as external packages and ignored for dead code purposes:
+Only **relative imports** (starting with `./` or `../`) and **configured aliases** are resolved to files in the project. Non-relative imports are treated as external packages and skipped from the dependency graph.
 
 ```ts
-import React from 'react';              // ignored — external
+import React from 'react';              // skipped — external package
 import { bar } from './local-module';   // resolved — analyzed
 ```
 
-Path aliases (e.g., `@/`, `~/`) are resolved when configured in `ts_config`:
+Path aliases (e.g., `@/`, `~/`) are resolved when configured:
 
 ```yaml
 ts_config:
   enabled: true
   baseUrl: .
   paths:
-    "@/*":           # @/lib/utils → src/lib/utils
+    "@/*":
       - src/*
-    "~/*":          # ~/components → src/components
-      - src/components/*
 ```
 
-```ts
-import { foo } from '@/lib/utils';   // resolved — analyzed
-import { bar } from '~/components'; // resolved — analyzed
-```
+Aliases not configured in `ts_config` are treated as external and skipped.
 
-If an alias is configured but the target file is not found, the import is marked with `review` confidence rather than `safe`.
+### Alias Resolution Edge Cases
+
+// [!code highlight]
+- **Scoped patterns** like `@scope/*` are not supported — only exact prefix matches (`@/*`, `~/*`)
+- **Multi-level wildcards** like `@utils/*/helper` resolve only the first match segment
+- **Missing targets** are marked `review` rather than `safe` (conservative)
 
 ---
 

--- a/docs/content/docs/limitations.mdx
+++ b/docs/content/docs/limitations.mdx
@@ -36,15 +36,32 @@ Prune has no way to determine which files are actually loaded at runtime. Files 
 
 ## Ignored Import Patterns
 
-Only **relative imports** (starting with `./` or `../`) are resolved to files in the project. Non-relative imports are treated as external packages and ignored for dead code purposes:
+Only **relative imports** (starting with `./` or `../`) and **configured aliases** are resolved to files in the project. Non-relative imports are treated as external packages and ignored for dead code purposes:
 
 ```ts
 import React from 'react';              // ignored — external
-import { foo } from '@/lib/utils';      // ignored — path alias, not resolved
 import { bar } from './local-module';   // resolved — analyzed
 ```
 
-**Path aliases** (e.g., `@/`, `~/`, `#`) are not resolved. If your project uses TypeScript path mappings, files imported only through aliases will appear as `unused_file` or `unused_export` findings unless they are also imported via relative paths or declared as entrypoints.
+Path aliases (e.g., `@/`, `~/`) are resolved when configured in `ts_config`:
+
+```yaml
+ts_config:
+  enabled: true
+  baseUrl: .
+  paths:
+    "@/*":           # @/lib/utils → src/lib/utils
+      - src/*
+    "~/*":          # ~/components → src/components
+      - src/components/*
+```
+
+```ts
+import { foo } from '@/lib/utils';   // resolved — analyzed
+import { bar } from '~/components'; // resolved — analyzed
+```
+
+If an alias is configured but the target file is not found, the import is marked with `review` confidence rather than `safe`.
 
 ---
 

--- a/docs/content/docs/limitations.mdx
+++ b/docs/content/docs/limitations.mdx
@@ -1,7 +1,7 @@
 ---
 title: Limitations
 description: Known limitations and edge cases of the current Prune implementation.
-icon: AlertTriangle
+icon: TriangleAlert
 ---
 
 Prune's analysis is purely static — it reads source files without executing them. This provides speed and safety, but also means there are scenarios where the tool cannot determine reachability with certainty, or may produce incorrect results.

--- a/docs/content/docs/output-format.mdx
+++ b/docs/content/docs/output-format.mdx
@@ -96,7 +96,7 @@ The `pretty` format is designed for developer readability. For automation or lar
 
 ## JSON Format
 
-Outputs the full findings list as a pretty-printed JSON array. Useful for programmatic processing of complete results.
+Outputs a structured JSON object with summary, findings, and metadata. Useful for programmatic processing of complete results.
 
 ```bash
 prune scan --format json
@@ -105,41 +105,73 @@ prune scan --format json
 **Example output:**
 
 ```json
-[
-  {
-    "id": "unused_file:src/utils/legacy.ts",
-    "kind": "unused_file",
-    "confidence": "safe",
-    "file": "src/utils/legacy.ts",
-    "line": 1,
-    "symbol": "legacy.ts",
-    "reason": "file is not referenced by any import"
+{
+  "summary": {
+    "files": 3,
+    "issues": 12,
+    "safe": 7,
+    "review": 5
   },
-  {
-    "id": "unused_export:src/components/Button.tsx:OldButtonVariant",
-    "kind": "unused_export",
-    "confidence": "safe",
-    "file": "src/components/Button.tsx",
-    "line": 42,
-    "symbol": "OldButtonVariant",
-    "reason": "exported symbol is never imported"
-  },
-  {
-    "id": "unused_function:src/lib/helpers.ts:formatDeprecated",
-    "kind": "unused_function",
-    "confidence": "likely_dead",
-    "file": "src/lib/helpers.ts",
-    "line": 18,
-    "symbol": "formatDeprecated",
-    "reason": "function declared but never referenced"
+  "findings": [
+    {
+      "id": "unused_file:src/utils/legacy.ts",
+      "kind": "unused_file",
+      "confidence": "safe",
+      "file": "src/utils/legacy.ts",
+      "line": 1,
+      "symbol": "legacy.ts",
+      "reason": "file is not referenced by any import"
+    },
+    {
+      "id": "unused_export:src/components/Button.tsx:OldButtonVariant",
+      "kind": "unused_export",
+      "confidence": "safe",
+      "file": "src/components/Button.tsx",
+      "line": 42,
+      "symbol": "OldButtonVariant",
+      "reason": "exported symbol is never imported"
+    },
+    {
+      "id": "unused_function:src/lib/helpers.ts:formatDeprecated",
+      "kind": "unused_function",
+      "confidence": "likely_dead",
+      "file": "src/lib/helpers.ts",
+      "line": 18,
+      "symbol": "formatDeprecated",
+      "reason": "function declared but never referenced"
+    }
+  ],
+  "metadata": {
+    "entrypoints": ["src/index.ts", "src/main.tsx", "src/pages/**"],
+    "scan_time_ms": 340
   }
-]
+}
 ```
 
-When no findings match the filter, an empty JSON array is returned:
+### Summary Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `files` | int | Unique file count with findings |
+| `issues` | int | Total number of findings |
+| `safe` | int | Findings with `confidence: "safe"` |
+| `review` | int | Findings with `confidence: "review"` or `"likely_dead"` |
+
+### Metadata Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `entrypoints` | string[] | Entrypoint files and patterns from config |
+| `scan_time_ms` | int | Scan duration in milliseconds |
+
+When no findings match the filter, an empty findings array is returned:
 
 ```json
-[]
+{
+  "summary": { "files": 0, "issues": 0, "safe": 0, "review": 0 },
+  "findings": [],
+  "metadata": { "entrypoints": [...], "scan_time_ms": 10 }
+}
 ```
 
 ---

--- a/docs/content/docs/output-format.mdx
+++ b/docs/content/docs/output-format.mdx
@@ -38,7 +38,7 @@ prune scan --format table  # alias for pretty
 **Example output:**
 
 ```bash
-Prune v0.1.0-beta.1 — 4 issues found in 340ms
+Prune 0.2.0-beta.1 — 4 issues found in 340ms
 
 ✔ SAFE (2)
 

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -81,7 +81,7 @@ Prune reads `prune.yaml` from the current directory, walks the declared scan pat
 **Example output (`pretty` format):**
 
 ```bash
-Prune v0.1.0-beta.1 — 4 issues found in 340ms
+Prune 0.2.0-beta.1 — 4 issues found in 340ms
 
 ✔ SAFE (2)
 

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -17,7 +17,7 @@ prune init
 This creates a `prune.yaml` file in the current directory with sensible defaults. The default configuration assumes a project in the `js-ts` language mode and scans the current directory for `.js`, `.jsx`, `.ts`, and `.tsx` files.
 
 ```yaml
-version: 1
+version: 2
 project:
   name: prune
   language: js-ts

--- a/docs/content/docs/quick-start.mdx
+++ b/docs/content/docs/quick-start.mdx
@@ -17,10 +17,21 @@ prune init
 This creates a `prune.yaml` file in the current directory with sensible defaults. The default configuration assumes a project in the `js-ts` language mode and scans the current directory for `.js`, `.jsx`, `.ts`, and `.tsx` files.
 
 ```yaml
+// [!code --]
+version: 1
+// [!code ++]
 version: 2
 project:
   name: prune
   language: js-ts
+
+ts_config:
+  enabled: true
+  baseUrl: .
+  paths:
+    "@/*":
+      - src/*
+
 scan:
   paths:
     - .

--- a/docs/src/app/(home)/_components/features.tsx
+++ b/docs/src/app/(home)/_components/features.tsx
@@ -29,6 +29,10 @@ export default function Features() {
           <h3 className="font-semibold text-xl">Machine Readable</h3>
           <p className="text-muted-foreground leading-relaxed text-sm sm:text-base text-justify sm:text-left">Output in <code className="bg-muted px-1.5 py-0.5 rounded border border-border text-[10px] sm:text-xs">json</code> or <code className="bg-muted px-1.5 py-0.5 rounded border border-border text-[10px] sm:text-xs">ndjson</code> for integrations and custom tooling.</p>
         </div>
+        <div className="flex flex-col gap-3">
+          <h3 className="font-semibold text-xl">Path Aliases</h3>
+          <p className="text-muted-foreground leading-relaxed text-sm sm:text-base text-justify sm:text-left">Resolves TypeScript path aliases like <code className="bg-muted px-1.5 py-0.5 rounded border-border text-[10px] sm:text-xs">@/</code> and <code className="bg-muted px-1.5 py-0.5 rounded border border-border text-[10px] sm:text-xs">~/</code> configured via <code className="bg-muted px-1.5 py-0.5 rounded border border-border text-[10px] sm:text-xs">ts_config</code>.</p>
+        </div>
       </div>
     </Section>
   );

--- a/docs/src/app/(home)/_components/solution.tsx
+++ b/docs/src/app/(home)/_components/solution.tsx
@@ -5,7 +5,7 @@ export default function Solution() {
     <Section className="flex-col gap-6 max-w-4xl mx-auto py-16 sm:py-24 border-y border-border bg-muted/30">
       <h2 className="text-3xl sm:text-4xl font-bold tracking-tight leading-tight">Precision-engineered code pruning</h2>
       <p className="text-lg sm:text-xl text-muted-foreground leading-relaxed">
-        Prune builds a complete dependency graph of your application starting from your actual entrypoints. If a file, function, or export isn't reachable from the root, it's flagged as dead code.
+        Prune builds a complete dependency graph of your application starting from your actual entrypoints—including resolving TypeScript path aliases like <code className="bg-muted px-1.5 py-0.5 rounded border border-border text-[10px] sm:text-xs">@/</code> and <code className="bg-muted px-1.5 py-0.5 rounded border border-border text-[10px] sm:text-xs">~/</code>. If a file, function, or export isn't reachable from the root, it's flagged as dead code.
       </p>
       <p className="text-lg sm:text-xl text-muted-foreground leading-relaxed">
         Built in Go and powered by Tree-sitter, Prune is fast enough to run as a pre-commit hook or as a blocking gate in your CI/CD pipeline. No more manual hunting—just a clean, leaner codebase.

--- a/docs/src/app/(home)/layout.tsx
+++ b/docs/src/app/(home)/layout.tsx
@@ -80,7 +80,7 @@ const jsonLd = {
   applicationCategory: 'DeveloperApplication',
   operatingSystem: 'Linux, macOS, Windows',
   url: BASE_URL,
-  softwareVersion: '0.1.0-beta.1',
+  softwareVersion: '0.2.0-beta.1',
   license: 'https://opensource.org/licenses/MIT',
   author: {
     '@type': 'Person',

--- a/examples/js-complex/prune.yaml
+++ b/examples/js-complex/prune.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 project:
     name: js-complex
     language: js-ts

--- a/examples/js-simple/prune.yaml
+++ b/examples/js-simple/prune.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 project:
     name: prune
     language: js-ts

--- a/examples/ts-alias/prune.yaml
+++ b/examples/ts-alias/prune.yaml
@@ -1,0 +1,36 @@
+version: 1
+project:
+    name: ts-alias
+    language: js-ts
+scan:
+    paths:
+        - src
+    include:
+        - '**/*.ts'
+        - '**/*.tsx'
+    exclude:
+        - node_modules/**
+entrypoints:
+    files:
+        - src/index.ts
+ts_config:
+    enabled: true
+    baseUrl: .
+    paths:
+        "@/*":
+            - src/*
+        "~/*":
+            - src/components/*
+rules:
+    unused_function:
+        enabled: true
+    unused_variable:
+        enabled: true
+    unused_export:
+        enabled: true
+    unused_file:
+        enabled: true
+report:
+    format: table
+    min_confidence: safe
+    include_evidence: true

--- a/examples/ts-alias/prune.yaml
+++ b/examples/ts-alias/prune.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 project:
     name: ts-alias
     language: js-ts

--- a/examples/ts-alias/src/components/Button.tsx
+++ b/examples/ts-alias/src/components/Button.tsx
@@ -1,0 +1,3 @@
+export const bar = "button";
+
+export const unusedButton = "unused";

--- a/examples/ts-alias/src/index.ts
+++ b/examples/ts-alias/src/index.ts
@@ -1,0 +1,5 @@
+import { foo } from "@/utils/helper";
+import { bar } from "~/components/Button";
+import { local } from "./local";
+
+console.log(foo, bar, local);

--- a/examples/ts-alias/src/local.ts
+++ b/examples/ts-alias/src/local.ts
@@ -1,0 +1,1 @@
+export const local = "local";

--- a/examples/ts-alias/src/utils/helper.ts
+++ b/examples/ts-alias/src/utils/helper.ts
@@ -1,0 +1,5 @@
+export const foo = "foo";
+
+export function unusedHelper() {
+    return "unused";
+}

--- a/examples/ts-complex/prune.yaml
+++ b/examples/ts-complex/prune.yaml
@@ -1,4 +1,4 @@
-version: 1
+version: 2
 project:
     name: ts-complex
     language: js-ts

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -8,7 +8,7 @@ import (
 	"os"
 )
 
-const version = "0.1.0-beta.1"
+const version = "0.2.0-beta.1"
 
 type rootOptions struct {
 	configPath     string

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -94,6 +94,7 @@ func runScan(ctx context.Context, args []string) error {
 		Compact:   opts.compact,
 		Only:      opts.only,
 		Deletable: opts.deletable,
+		Config:    cfg,
 	})
 	if err != nil {
 		return fmt.Errorf("creating formatter: %w", err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,11 +33,18 @@ type Config struct {
 		MinConfidence   string `yaml:"min_confidence"`
 		IncludeEvidence bool   `yaml:"include_evidence"`
 	} `yaml:"report"`
+	TsConfig TsConfig `yaml:"ts_config"`
 }
 
 type StreamConfig struct {
 	Enabled    bool `yaml:"enabled"`
 	IntervalMs int  `yaml:"interval_ms"`
+}
+
+type TsConfig struct {
+	Enabled bool                `yaml:"enabled"`
+	BaseURL string              `yaml:"baseUrl"`
+	Paths   map[string][]string `yaml:"paths"`
 }
 
 type RuleConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -48,8 +48,8 @@ func TestWriteDefault(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.Version != 1 {
-		t.Fatalf("expected version 1")
+	if cfg.Version != 2 {
+		t.Fatalf("expected version 2")
 	}
 	if cfg.Project.Language != "js-ts" {
 		t.Fatalf("expected js-ts language")

--- a/internal/config/default.go
+++ b/internal/config/default.go
@@ -16,7 +16,7 @@ func WriteDefault(path string) error {
 }
 
 func defaultConfig() *Config {
-	cfg := &Config{Version: 1}
+	cfg := &Config{Version: 2}
 	cfg.Project.Name = "prune"
 	cfg.Project.Language = "js-ts"
 	cfg.Scan.Paths = []string{"."}
@@ -78,5 +78,6 @@ func defaultConfig() *Config {
 	cfg.Report.Format = "table"
 	cfg.Report.MinConfidence = "safe"
 	cfg.Report.IncludeEvidence = true
+	cfg.TsConfig.Enabled = false
 	return cfg
 }

--- a/internal/lang/js/collector.go
+++ b/internal/lang/js/collector.go
@@ -15,6 +15,7 @@ import (
 
 type Collector struct {
 	cfg               *config.Config
+	resolver          *Resolver
 	imports           map[string][]string
 	importSpecs       map[string][]ImportSpec
 	importsResolved   map[string][]string
@@ -90,6 +91,8 @@ func (c *Collector) Collect(ctx context.Context, entries []scan.FileEntry) (*Col
 		fileIndex[entry.Rel] = entry
 	}
 
+	c.resolver = NewResolver(c.cfg, fileIndex)
+
 	patterns := c.cfg.FeatureFlags.Patterns
 	flagRegexes := compileRegexes(patterns)
 
@@ -109,7 +112,9 @@ func (c *Collector) Collect(ctx context.Context, entries []scan.FileEntry) (*Col
 			if importSpecs[i].SideEffect {
 				continue
 			}
-			importSpecs[i].Resolved = resolveImportSpec(entry.Rel, importSpecs[i], fileIndex)
+			resolved := c.resolver.Resolve(importSpecs[i].Source, entry.Rel)
+			importSpecs[i].Resolved = resolved.Resolved
+			importSpecs[i].Confidence = resolved.Confidence
 		}
 		c.imports[entry.Rel] = rawImports
 		c.importSpecs[entry.Rel] = importSpecs
@@ -278,6 +283,7 @@ func readFile(path string) (string, error) {
 type ImportSpec struct {
 	Source     string
 	Resolved   string
+	Confidence string
 	Names      []string
 	Wildcard   bool
 	SideEffect bool

--- a/internal/lang/js/resolver.go
+++ b/internal/lang/js/resolver.go
@@ -1,0 +1,231 @@
+package js
+
+import (
+	"path/filepath"
+	"strings"
+
+	"prune/internal/config"
+	"prune/internal/scan"
+)
+
+type ImportType int
+
+const (
+	ImportTypeUnknown ImportType = iota
+	ImportTypeRelative
+	ImportTypeAlias
+	ImportTypeExternal
+)
+
+type ResolvedImport struct {
+	Type       ImportType
+	Original   string
+	Resolved   string
+	Confidence string
+}
+
+type Resolver struct {
+	cfg        *config.Config
+	fileIndex  map[string]scan.FileEntry
+	baseURL    string
+	aliasPaths map[string][]string
+}
+
+func NewResolver(cfg *config.Config, fileIndex map[string]scan.FileEntry) *Resolver {
+	r := &Resolver{
+		cfg:        cfg,
+		fileIndex:  fileIndex,
+		baseURL:    cfg.TsConfig.BaseURL,
+		aliasPaths: cfg.TsConfig.Paths,
+	}
+	if r.baseURL == "" {
+		r.baseURL = "."
+	}
+	return r
+}
+
+func (r *Resolver) Resolve(source, fromFile string) ResolvedImport {
+	importType := r.Classify(source)
+
+	switch importType {
+	case ImportTypeRelative:
+		return r.resolveRelative(source, fromFile)
+	case ImportTypeAlias:
+		return r.resolveAlias(source, fromFile)
+	case ImportTypeExternal:
+		return ResolvedImport{
+			Type:       ImportTypeExternal,
+			Original:   source,
+			Resolved:   "",
+			Confidence: "safe",
+		}
+	default:
+		return ResolvedImport{
+			Type:       ImportTypeUnknown,
+			Original:   source,
+			Resolved:   "",
+			Confidence: "review",
+		}
+	}
+}
+
+func (r *Resolver) Classify(source string) ImportType {
+	if strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") {
+		return ImportTypeRelative
+	}
+
+	if r.aliasPaths != nil && len(r.aliasPaths) > 0 {
+		for alias := range r.aliasPaths {
+			if strings.HasPrefix(source, strings.TrimSuffix(alias, "/*")) {
+				return ImportTypeAlias
+			}
+		}
+	}
+
+	if r.isExternal(source) {
+		return ImportTypeExternal
+	}
+
+	if strings.HasPrefix(source, "@/") {
+		return ImportTypeAlias
+	}
+
+	return ImportTypeRelative
+}
+
+func (r *Resolver) resolveRelative(source, fromFile string) ResolvedImport {
+	base := filepath.Dir(fromFile)
+	candidate := filepath.ToSlash(filepath.Clean(filepath.Join(base, source)))
+
+	if target, ok := r.resolveFile(candidate); ok {
+		return ResolvedImport{
+			Type:       ImportTypeRelative,
+			Original:   source,
+			Resolved:   target,
+			Confidence: "safe",
+		}
+	}
+
+	return ResolvedImport{
+		Type:       ImportTypeRelative,
+		Original:   source,
+		Resolved:   "",
+		Confidence: "review",
+	}
+}
+
+func (r *Resolver) resolveAlias(source, fromFile string) ResolvedImport {
+	if r.aliasPaths == nil {
+		return ResolvedImport{
+			Type:       ImportTypeAlias,
+			Original:   source,
+			Resolved:   "",
+			Confidence: "review",
+		}
+	}
+
+	for alias, targets := range r.aliasPaths {
+		prefix := strings.TrimSuffix(alias, "/*")
+		if !strings.HasPrefix(source, prefix) {
+			continue
+		}
+
+		if len(targets) == 0 {
+			continue
+		}
+
+		mapping := targets[0]
+		suffix := strings.TrimPrefix(source, prefix)
+		suffix = strings.TrimPrefix(suffix, "/")
+
+		mappingBase := strings.TrimSuffix(mapping, "/*")
+		baseURL := r.baseURL
+		if baseURL == "." {
+			baseURL = ""
+		}
+		resolvedPath := filepath.ToSlash(filepath.Clean(filepath.Join(baseURL, mappingBase, suffix)))
+
+		if target, ok := r.resolveFile(resolvedPath); ok {
+			return ResolvedImport{
+				Type:       ImportTypeAlias,
+				Original:   source,
+				Resolved:   target,
+				Confidence: "safe",
+			}
+		}
+
+		return ResolvedImport{
+			Type:       ImportTypeAlias,
+			Original:   source,
+			Resolved:   "",
+			Confidence: "review",
+		}
+	}
+
+	return ResolvedImport{
+		Type:       ImportTypeAlias,
+		Original:   source,
+		Resolved:   "",
+		Confidence: "review",
+	}
+}
+
+func (r *Resolver) resolveFile(path string) (string, bool) {
+	if _, ok := r.fileIndex[path]; ok {
+		return path, true
+	}
+
+	extensions := []string{".ts", ".tsx", ".js", ".jsx"}
+	for _, ext := range extensions {
+		candidate := path + ext
+		if _, ok := r.fileIndex[candidate]; ok {
+			return candidate, true
+		}
+	}
+	for _, ext := range extensions {
+		candidate := filepath.ToSlash(filepath.Join(path, "index"+ext))
+		if _, ok := r.fileIndex[candidate]; ok {
+			return candidate, true
+		}
+	}
+	return "", false
+}
+
+func (r *Resolver) isExternal(source string) bool {
+	if strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") || strings.HasPrefix(source, "@/") {
+		return false
+	}
+	parts := strings.Split(source, "/")
+	if len(parts) == 0 {
+		return false
+	}
+	first := parts[0]
+	if strings.HasPrefix(first, "@") && !strings.HasPrefix(source, "@/") {
+		return true
+	}
+	if strings.HasPrefix(first, ".") {
+		return false
+	}
+	return true
+}
+
+func ResolveFile(path string, index map[string]scan.FileEntry) (string, bool) {
+	if _, ok := index[path]; ok {
+		return path, true
+	}
+
+	extensions := []string{".ts", ".tsx", ".js", ".jsx"}
+	for _, ext := range extensions {
+		candidate := path + ext
+		if _, ok := index[candidate]; ok {
+			return candidate, true
+		}
+	}
+	for _, ext := range extensions {
+		candidate := filepath.ToSlash(filepath.Join(path, "index"+ext))
+		if _, ok := index[candidate]; ok {
+			return candidate, true
+		}
+	}
+	return "", false
+}

--- a/internal/lang/js/resolver_test.go
+++ b/internal/lang/js/resolver_test.go
@@ -1,0 +1,168 @@
+package js
+
+import (
+	"testing"
+
+	"prune/internal/config"
+	"prune/internal/scan"
+)
+
+func TestResolveRelative(t *testing.T) {
+	cfg := &config.Config{}
+	fileIndex := map[string]scan.FileEntry{
+		"src/local.ts":        {Path: "testdata/src/local.ts", Rel: "src/local.ts"},
+		"src/utils/helper.ts": {Path: "testdata/src/utils/helper.ts", Rel: "src/utils/helper.ts"},
+		"src/main.ts":         {Path: "testdata/src/main.ts", Rel: "src/main.ts"},
+	}
+
+	r := NewResolver(cfg, fileIndex)
+
+	tests := []struct {
+		name     string
+		source   string
+		fromFile string
+		wantType ImportType
+		wantRes  string
+		wantConf string
+	}{
+		{"relative dot", "./local", "src/main.ts", ImportTypeRelative, "src/local.ts", "safe"},
+		{"relative dotdot", "../other", "src/utils/helper.ts", ImportTypeRelative, "", "review"},
+		{"relative subdir", "./utils/helper", "src/main.ts", ImportTypeRelative, "src/utils/helper.ts", "safe"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.Resolve(tt.source, tt.fromFile)
+			if got.Type != tt.wantType {
+				t.Errorf("type = %v, want %v", got.Type, tt.wantType)
+			}
+			if got.Resolved != tt.wantRes {
+				t.Errorf("resolved = %q, want %q", got.Resolved, tt.wantRes)
+			}
+			if got.Confidence != tt.wantConf {
+				t.Errorf("confidence = %q, want %q", got.Confidence, tt.wantConf)
+			}
+		})
+	}
+}
+
+func TestResolveAlias(t *testing.T) {
+	cfg := &config.Config{
+		TsConfig: config.TsConfig{
+			Enabled: true,
+			BaseURL: ".",
+			Paths: map[string][]string{
+				"@/*": {"src/*"},
+			},
+		},
+	}
+	fileIndex := map[string]scan.FileEntry{
+		"src/main.ts":         {Path: "testdata/src/main.ts", Rel: "src/main.ts"},
+		"src/utils/helper.ts": {Path: "testdata/src/utils/helper.ts", Rel: "src/utils/helper.ts"},
+	}
+
+	r := NewResolver(cfg, fileIndex)
+
+	got := r.Resolve("@/utils/helper", "src/main.ts")
+	if got.Type != ImportTypeAlias {
+		t.Errorf("type = %v, want %v", got.Type, ImportTypeAlias)
+	}
+	if got.Resolved != "src/utils/helper.ts" {
+		t.Errorf("resolved = %q, want %q", got.Resolved, "src/utils/helper.ts")
+	}
+	if got.Confidence != "safe" {
+		t.Errorf("confidence = %q, want %q", got.Confidence, "safe")
+	}
+}
+
+func TestResolveAliasNotFound(t *testing.T) {
+	cfg := &config.Config{
+		TsConfig: config.TsConfig{
+			Enabled: true,
+			BaseURL: ".",
+			Paths: map[string][]string{
+				"@/*": {"src/*"},
+			},
+		},
+	}
+	fileIndex := map[string]scan.FileEntry{
+		"src/main.ts": {Path: "testdata/src/main.ts", Rel: "src/main.ts"},
+	}
+
+	r := NewResolver(cfg, fileIndex)
+
+	got := r.Resolve("@/nonexistent", "src/main.ts")
+	if got.Type != ImportTypeAlias {
+		t.Errorf("type = %v, want %v", got.Type, ImportTypeAlias)
+	}
+	if got.Resolved != "" {
+		t.Errorf("resolved = %q, want empty", got.Resolved)
+	}
+	if got.Confidence != "review" {
+		t.Errorf("confidence = %q, want %q", got.Confidence, "review")
+	}
+}
+
+func TestResolveExternal(t *testing.T) {
+	cfg := &config.Config{}
+	fileIndex := map[string]scan.FileEntry{
+		"src/main.ts": {Path: "testdata/src/main.ts", Rel: "src/main.ts"},
+	}
+
+	r := NewResolver(cfg, fileIndex)
+
+	tests := []struct {
+		name     string
+		source   string
+		wantType ImportType
+		wantConf string
+	}{
+		{"lodash", "lodash", ImportTypeExternal, "safe"},
+		{"react", "react", ImportTypeExternal, "safe"},
+		{"@scope/pkg", "@scope/pkg", ImportTypeExternal, "safe"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := r.Resolve(tt.source, "src/main.ts")
+			if got.Type != tt.wantType {
+				t.Errorf("type = %v, want %v", got.Type, tt.wantType)
+			}
+			if got.Confidence != tt.wantConf {
+				t.Errorf("confidence = %q, want %q", got.Confidence, tt.wantConf)
+			}
+		})
+	}
+}
+
+func TestClassify(t *testing.T) {
+	cfg := &config.Config{
+		TsConfig: config.TsConfig{
+			Enabled: true,
+			BaseURL: ".",
+			Paths: map[string][]string{
+				"@/*": {"src/*"},
+			},
+		},
+	}
+	r := NewResolver(cfg, nil)
+
+	tests := []struct {
+		source   string
+		wantType ImportType
+	}{
+		{"./local", ImportTypeRelative},
+		{"../parent", ImportTypeRelative},
+		{"@/utils", ImportTypeAlias},
+		{"lodash", ImportTypeExternal},
+		{"react", ImportTypeExternal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			if got := r.Classify(tt.source); got != tt.wantType {
+				t.Errorf("classify(%q) = %v, want %v", tt.source, got, tt.wantType)
+			}
+		})
+	}
+}

--- a/internal/lang/js/testdata_resolver/main.ts
+++ b/internal/lang/js/testdata_resolver/main.ts
@@ -1,0 +1,4 @@
+import { foo } from "@/utils/helper"
+import "./local"
+import "lodash"
+export const main = 1

--- a/internal/lang/js/testdata_resolver/src/local.ts
+++ b/internal/lang/js/testdata_resolver/src/local.ts
@@ -1,0 +1,1 @@
+export const local = "local"

--- a/internal/lang/js/testdata_resolver/src/utils/helper.ts
+++ b/internal/lang/js/testdata_resolver/src/utils/helper.ts
@@ -1,0 +1,1 @@
+export const foo = "helper"

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -11,7 +11,7 @@ import (
 	"prune/internal/rules"
 )
 
-var version = "0.1.0-beta.1"
+var version = "0.2.0-beta.1"
 
 type FormatterOptions struct {
 	Duration  time.Duration

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -7,6 +7,7 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"prune/internal/config"
 	"prune/internal/rules"
 )
 
@@ -17,6 +18,7 @@ type FormatterOptions struct {
 	Compact   bool
 	Only      string
 	Deletable bool
+	Config    *config.Config
 }
 
 type Formatter interface {
@@ -31,7 +33,7 @@ func NewFormatter(format string, opts ...FormatterOptions) (Formatter, error) {
 
 	switch strings.ToLower(format) {
 	case "json":
-		return jsonFormatter{}, nil
+		return jsonFormatter{opts: o}, nil
 	case "ndjson":
 		return ndjsonFormatter{}, nil
 	case "table", "pretty":
@@ -56,10 +58,74 @@ func FilterByConfidence(findings []rules.Finding, min string) []rules.Finding {
 	return filtered
 }
 
-type jsonFormatter struct{}
+type JSONReport struct {
+	Summary  Summary         `json:"summary"`
+	Findings []rules.Finding `json:"findings"`
+	Metadata Metadata        `json:"metadata"`
+}
+
+type Summary struct {
+	Files  int `json:"files"`
+	Issues int `json:"issues"`
+	Safe   int `json:"safe"`
+	Review int `json:"review"`
+}
+
+type Metadata struct {
+	Entrypoints []string `json:"entrypoints"`
+	ScanTimeMs  int64    `json:"scan_time_ms"`
+}
+
+func buildSummary(findings []rules.Finding) Summary {
+	uniqueFiles := map[string]bool{}
+	safeCount := 0
+	reviewCount := 0
+
+	for _, f := range findings {
+		if f.File != "" {
+			uniqueFiles[f.File] = true
+		}
+		switch f.Confidence {
+		case "safe":
+			safeCount++
+		case "likely_dead", "review":
+			reviewCount++
+		}
+	}
+
+	return Summary{
+		Files:  len(uniqueFiles),
+		Issues: len(findings),
+		Safe:   safeCount,
+		Review: reviewCount,
+	}
+}
+
+func buildMetadata(opts FormatterOptions) Metadata {
+	entrypoints := []string{}
+	if opts.Config != nil {
+		entrypoints = append(entrypoints, opts.Config.Entrypoints.Files...)
+		entrypoints = append(entrypoints, opts.Config.Entrypoints.Patterns...)
+	}
+	return Metadata{
+		Entrypoints: entrypoints,
+		ScanTimeMs:  opts.Duration.Milliseconds(),
+	}
+}
+
+type jsonFormatter struct {
+	opts FormatterOptions
+}
 
 func (f jsonFormatter) Format(findings []rules.Finding) ([]byte, error) {
-	return json.MarshalIndent(findings, "", "  ")
+	summary := buildSummary(findings)
+	metadata := buildMetadata(f.opts)
+	report := JSONReport{
+		Summary:  summary,
+		Findings: findings,
+		Metadata: metadata,
+	}
+	return json.MarshalIndent(report, "", "  ")
 }
 
 type ndjsonFormatter struct{}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
+	"prune/internal/config"
 	"prune/internal/rules"
 )
 
@@ -62,12 +64,120 @@ func TestJSONFormatter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	var decoded []rules.Finding
-	if err := json.Unmarshal(data, &decoded); err != nil {
+	var report JSONReport
+	if err := json.Unmarshal(data, &report); err != nil {
 		t.Fatalf("invalid json output: %v", err)
 	}
-	if len(decoded) != 1 || decoded[0].ID != "f1" {
+	if len(report.Findings) != 1 || report.Findings[0].ID != "f1" {
 		t.Fatalf("unexpected json output")
+	}
+	if report.Summary.Files != 1 {
+		t.Fatalf("expected 1 file in summary, got %d", report.Summary.Files)
+	}
+	if report.Summary.Issues != 1 {
+		t.Fatalf("expected 1 issue in summary, got %d", report.Summary.Issues)
+	}
+}
+
+func TestJSONFormatterSummary(t *testing.T) {
+	formatter, err := NewFormatter("json", FormatterOptions{
+		Duration: 984 * time.Millisecond,
+	})
+	if err != nil || formatter == nil {
+		t.Fatalf("missing json formatter, err: %v", err)
+	}
+
+	findings := []rules.Finding{
+		{Confidence: "safe", Kind: "unused_file", File: "a.ts"},
+		{Confidence: "safe", Kind: "unused_file", File: "b.ts"},
+		{Confidence: "review", Kind: "suspicious_dynamic_usage", File: "c.ts"},
+		{Confidence: "likely_dead", Kind: "unused_function", File: "d.ts"},
+	}
+	data, err := formatter.Format(findings)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var report JSONReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("invalid json output: %v", err)
+	}
+
+	if report.Summary.Files != 4 {
+		t.Errorf("expected 4 files, got %d", report.Summary.Files)
+	}
+	if report.Summary.Issues != 4 {
+		t.Errorf("expected 4 issues, got %d", report.Summary.Issues)
+	}
+	if report.Summary.Safe != 2 {
+		t.Errorf("expected 2 safe, got %d", report.Summary.Safe)
+	}
+	if report.Summary.Review != 2 {
+		t.Errorf("expected 2 review (includes likely_dead), got %d", report.Summary.Review)
+	}
+	if report.Metadata.ScanTimeMs != 984 {
+		t.Errorf("expected scan_time_ms 984, got %d", report.Metadata.ScanTimeMs)
+	}
+}
+
+func TestJSONFormatterWithConfig(t *testing.T) {
+	cfg := &config.Config{
+		Version: 1,
+	}
+	cfg.Entrypoints.Files = []string{"src/index.ts", "src/main.tsx"}
+	cfg.Entrypoints.Patterns = []string{"src/pages/**"}
+
+	formatter, err := NewFormatter("json", FormatterOptions{
+		Config: cfg,
+	})
+	if err != nil || formatter == nil {
+		t.Fatalf("missing json formatter, err: %v", err)
+	}
+
+	data, err := formatter.Format(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var report JSONReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("invalid json output: %v", err)
+	}
+
+	if len(report.Metadata.Entrypoints) != 3 {
+		t.Errorf("expected 3 entrypoints, got %d: %v", len(report.Metadata.Entrypoints), report.Metadata.Entrypoints)
+	}
+}
+
+func TestJSONFormatterNoFindings(t *testing.T) {
+	formatter, err := NewFormatter("json", FormatterOptions{
+		Duration: 100 * time.Millisecond,
+	})
+	if err != nil || formatter == nil {
+		t.Fatalf("missing json formatter, err: %v", err)
+	}
+
+	data, err := formatter.Format(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var report JSONReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		t.Fatalf("invalid json output: %v", err)
+	}
+
+	if report.Summary.Files != 0 {
+		t.Errorf("expected 0 files, got %d", report.Summary.Files)
+	}
+	if report.Summary.Issues != 0 {
+		t.Errorf("expected 0 issues, got %d", report.Summary.Issues)
+	}
+	if report.Summary.Safe != 0 {
+		t.Errorf("expected 0 safe, got %d", report.Summary.Safe)
+	}
+	if report.Summary.Review != 0 {
+		t.Errorf("expected 0 review, got %d", report.Summary.Review)
 	}
 }
 


### PR DESCRIPTION
This pull request updates the documentation and example configuration for the Prune static analysis tool to reflect the new 0.2.0-beta.1 release. The most significant changes introduce support for TypeScript path alias resolution via a new `ts_config` section in the configuration, update the JSON output structure, and increment the configuration schema version to 2. The documentation is revised throughout to explain these new features, update usage examples, and clarify limitations.

**Key changes:**

### Path Alias Resolution & Configuration

* Added support for resolving TypeScript path aliases (e.g., `@/`, `~/`) via a new `ts_config` section in `prune.yaml`, including `enabled`, `baseUrl`, and `paths` options. Documentation and configuration examples are updated accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23) [[2]](diffhunk://#diff-c9adbf67e6641855163c5b94f50fa7a2109dd9ecd9788a3f6167bbc6fc97c105L9-R115) [[3]](diffhunk://#diff-c9adbf67e6641855163c5b94f50fa7a2109dd9ecd9788a3f6167bbc6fc97c105R442-R483) [[4]](diffhunk://#diff-c9adbf67e6641855163c5b94f50fa7a2109dd9ecd9788a3f6167bbc6fc97c105L9-R115) [[5]](diffhunk://#diff-01922a29d5ae03bc9d250e3a81fa6ea18129e1304599ede19e90cd9ec058bdcdL1-R1) [[6]](diffhunk://#diff-0329c21f207fe60c03c1feedd45c29e1277b44e5a536502fbbbdbaf389f71504R20-R34) [[7]](diffhunk://#diff-0329c21f207fe60c03c1feedd45c29e1277b44e5a536502fbbbdbaf389f71504L73-R84) [[8]](diffhunk://#diff-a8066d118f3510ea66b1810d79480da37c489ca5d556ee27df990687b2bddc3dL141-R179)
* Updated the limitations documentation to clarify how aliases are resolved, edge cases, and unsupported patterns (e.g., scoped aliases like `@scope/*`).

### Configuration Schema and Migration

* Incremented the configuration schema version from 1 to 2, with migration instructions and backwards compatibility notes. All examples and references now use `version: 2`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L158-R212) [[2]](diffhunk://#diff-c9adbf67e6641855163c5b94f50fa7a2109dd9ecd9788a3f6167bbc6fc97c105L9-R115) [[3]](diffhunk://#diff-c9adbf67e6641855163c5b94f50fa7a2109dd9ecd9788a3f6167bbc6fc97c105L105-R205) [[4]](diffhunk://#diff-a8066d118f3510ea66b1810d79480da37c489ca5d556ee27df990687b2bddc3dL141-R179) [[5]](diffhunk://#diff-01922a29d5ae03bc9d250e3a81fa6ea18129e1304599ede19e90cd9ec058bdcdL1-R1) [[6]](diffhunk://#diff-0329c21f207fe60c03c1feedd45c29e1277b44e5a536502fbbbdbaf389f71504R20-R34)

### Output Format and CLI Flags

* Updated the JSON output format: findings are now wrapped in an object with `summary`, `findings`, and `metadata` fields. Documentation and CLI usage examples are updated to match the new structure. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R129-R165) [[2]](diffhunk://#diff-7fb650018c3d320eaeb77bf4ab4f1ea41de71f3b7b2996897083b38fcc87e590L99-R99) [[3]](diffhunk://#diff-7fb650018c3d320eaeb77bf4ab4f1ea41de71f3b7b2996897083b38fcc87e590L108-R115) [[4]](diffhunk://#diff-7fb650018c3d320eaeb77bf4ab4f1ea41de71f3b7b2996897083b38fcc87e590L136-R174) [[5]](diffhunk://#diff-a8066d118f3510ea66b1810d79480da37c489ca5d556ee27df990687b2bddc3dR101-R122)
* Added new CLI flags: `--compact`, `--only`, and `--deletable`, with documentation.

### Documentation and Branding Updates

* Updated all references to the new version number (`0.2.0-beta.1`) across documentation, CLI output, and metadata. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R82-R90) [[3]](diffhunk://#diff-8a1c229cbb3ec48dd2e05d5661e7c72d5d005781c0b1f788003ccb2ae26c3f4bL30-R30) [[4]](diffhunk://#diff-ba82586ad92db39dbd2ac8217dcbc24d7fb61452e2b1082d5040be08e5424118L60-R60) [[5]](diffhunk://#diff-33eb596e5e575066b98af747471fbb6d63a3272563763093d0c4fd7839218a7dL83-R83) [[6]](diffhunk://#diff-7fb650018c3d320eaeb77bf4ab4f1ea41de71f3b7b2996897083b38fcc87e590L41-R41) [[7]](diffhunk://#diff-0329c21f207fe60c03c1feedd45c29e1277b44e5a536502fbbbdbaf389f71504L73-R84)
* Added and revised feature descriptions and limitations to highlight path alias support and clarify current restrictions. [[1]](diffhunk://#diff-32ccb32d7284893bfb82e2e62cd24331b32dd014b4e4c37581a2ddb10a319d0fR32-R35) [[2]](diffhunk://#diff-207491bb29bcf2d49f478c390d8fe3374fcea0c000e1d93379acf20c9b87c14bL8-R8) [[3]](diffhunk://#diff-470ff85ee858e92cb2d526aeaa53a7da0404a3b7c97ec09d149ae2db650789aaL4-R4) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R292)

**References:**  
[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R82-R90) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R129-R165) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L158-R212) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R292) [[7]](diffhunk://#diff-8a1c229cbb3ec48dd2e05d5661e7c72d5d005781c0b1f788003ccb2ae26c3f4bL30-R30) [[8]](diffhunk://#diff-c9adbf67e6641855163c5b94f50fa7a2109dd9ecd9788a3f6167bbc6fc97c105L9-R115) [[9]](diffhunk://#diff-c9adbf67e6641855163c5b94f50fa7a2109dd9ecd9788a3f6167bbc6fc97c105L105-R205) [[10]](diffhunk://#diff-c9adbf67e6641855163c5b94f50fa7a2109dd9ecd9788a3f6167bbc6fc97c105R442-R483) [[11]](diffhunk://#diff-ba82586ad92db39dbd2ac8217dcbc24d7fb61452e2b1082d5040be08e5424118L60-R60) [[12]](diffhunk://#diff-470ff85ee858e92cb2d526aeaa53a7da0404a3b7c97ec09d149ae2db650789aaL4-R4) [[13]](diffhunk://#diff-470ff85ee858e92cb2d526aeaa53a7da0404a3b7c97ec09d149ae2db650789aaL39-R64) [[14]](diffhunk://#diff-7fb650018c3d320eaeb77bf4ab4f1ea41de71f3b7b2996897083b38fcc87e590L41-R41) [[15]](diffhunk://#diff-7fb650018c3d320eaeb77bf4ab4f1ea41de71f3b7b2996897083b38fcc87e590L99-R99) [[16]](diffhunk://#diff-7fb650018c3d320eaeb77bf4ab4f1ea41de71f3b7b2996897083b38fcc87e590L108-R115) [[17]](diffhunk://#diff-7fb650018c3d320eaeb77bf4ab4f1ea41de71f3b7b2996897083b38fcc87e590L136-R174) [[18]](diffhunk://#diff-a8066d118f3510ea66b1810d79480da37c489ca5d556ee27df990687b2bddc3dR101-R122) [[19]](diffhunk://#diff-a8066d118f3510ea66b1810d79480da37c489ca5d556ee27df990687b2bddc3dR137) [[20]](diffhunk://#diff-a8066d118f3510ea66b1810d79480da37c489ca5d556ee27df990687b2bddc3dL141-R179) [[21]](diffhunk://#diff-33eb596e5e575066b98af747471fbb6d63a3272563763093d0c4fd7839218a7dL83-R83) [[22]](diffhunk://#diff-32ccb32d7284893bfb82e2e62cd24331b32dd014b4e4c37581a2ddb10a319d0fR32-R35) [[23]](diffhunk://#diff-207491bb29bcf2d49f478c390d8fe3374fcea0c000e1d93379acf20c9b87c14bL8-R8) [[24]](diffhunk://#diff-01922a29d5ae03bc9d250e3a81fa6ea18129e1304599ede19e90cd9ec058bdcdL1-R1) [[25]](diffhunk://#diff-0329c21f207fe60c03c1feedd45c29e1277b44e5a536502fbbbdbaf389f71504R20-R34) [[26]](diffhunk://#diff-0329c21f207fe60c03c1feedd45c29e1277b44e5a536502fbbbdbaf389f71504L73-R84)