### PR TITLE
Fix streaming collector duplication

### DIFF
--- a/internal/lang/js/streaming.go
+++ b/internal/lang/js/streaming.go
@@ -25,7 +25,8 @@ func AnalyzeStreaming(ctx context.Context, cfg *config.Config, handler StreamHan
 	}
 
 	collector := NewCollector(cfg)
-	allFindings := []rules.Finding{}
+	var lastCollected *Collected
+	emitted := map[string]bool{}
 
 	entriesCh := make(chan []scan.FileEntry, 1)
 	errCh := make(chan error, 1)
@@ -74,17 +75,30 @@ func AnalyzeStreaming(ctx context.Context, cfg *config.Config, handler StreamHan
 		if err != nil {
 			return nil, err
 		}
-
+		lastCollected = collected
 		findings := applyRules(cfg, collected)
-		allFindings = append(allFindings, findings...)
 		processed += len(batch)
 
 		if stream.Enabled && stream.IntervalMs > 0 && handler != nil {
-			if err := handler(findings); err != nil {
+			newFindings := make([]rules.Finding, 0, len(findings))
+			for _, finding := range findings {
+				if emitted[finding.ID] {
+					continue
+				}
+				emitted[finding.ID] = true
+				newFindings = append(newFindings, finding)
+			}
+			if len(newFindings) == 0 {
+				continue
+			}
+			if err := handler(newFindings); err != nil {
 				return nil, err
 			}
 		}
 	}
 
-	return allFindings, nil
+	if lastCollected == nil {
+		return nil, nil
+	}
+	return applyRules(cfg, lastCollected), nil
 }

--- a/internal/lang/js/streaming_test.go
+++ b/internal/lang/js/streaming_test.go
@@ -1,0 +1,73 @@
+package js
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"prune/internal/config"
+	"prune/internal/rules"
+)
+
+func TestAnalyzeStreamingMatchesNonStreaming(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	cfg := &config.Config{Version: 1}
+	cfg.Scan.Paths = []string{filepath.Join(root, "internal", "cli", "testdata", "streaming", "src")}
+	cfg.Scan.Include = []string{"**/*.ts"}
+	cfg.Scan.Stream.Enabled = true
+	cfg.Scan.Stream.IntervalMs = 1
+	cfg.Scan.Stream.BatchSize = 1
+
+	var streamedBatches [][]rules.Finding
+	cfg.Entrypoints.Files = []string{
+		filepath.ToSlash(cfg.Scan.Paths[0]) + "/index.ts",
+	}
+
+	_, err = AnalyzeStreaming(context.Background(), cfg, func(batch []rules.Finding) error {
+		streamedBatches = append(streamedBatches, batch)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("streaming analyze: %v", err)
+	}
+
+	streamedFinal, err := AnalyzeStreaming(context.Background(), cfg, nil)
+	if err != nil {
+		t.Fatalf("streaming final analyze: %v", err)
+	}
+
+	seen := map[string]int{}
+	for _, batch := range streamedBatches {
+		for _, finding := range batch {
+			seen[finding.ID]++
+		}
+	}
+	for id, count := range seen {
+		if count != 1 {
+			t.Fatalf("expected finding %q once in streamed batches, got %d", id, count)
+		}
+	}
+
+	finalSeen := map[string]int{}
+	for _, finding := range streamedFinal {
+		finalSeen[finding.ID]++
+	}
+	for id, count := range finalSeen {
+		if count != 1 {
+			t.Fatalf("expected final findings to be unique for %q, got %d", id, count)
+		}
+	}
+}
+
+func repoRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(filepath.Join(wd, "..", "..", "..")), nil
+}


### PR DESCRIPTION
## Summary
- keep a single collector for streaming batches and emit deduplicated findings
- return final findings from the full collected state to match non-streaming results
- add a streaming regression test for uniqueness in batches and final output

## Testing
- make test