### PR TITLE
Fix streaming cancellation handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module prune
 
-go 1.24
+go 1.25.0
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
@@ -8,3 +8,5 @@ require (
 )
 
 require github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
+
+require golang.org/x/sync v0.20.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82 h1:6C8qej6f
 github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82/go.mod h1:xe4pgH49k4SsmkQq5OT8abwhWmnzkhpgnXeekbx2efw=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/internal/lang/js/streaming.go
+++ b/internal/lang/js/streaming.go
@@ -122,10 +122,6 @@ func AnalyzeStreaming(ctx context.Context, cfg *config.Config, handler StreamHan
 		return nil, err
 	}
 
-	select {
-	case result := <-resultsCh:
-		return result, nil
-	default:
-		return nil, nil
-	}
+	result := <-resultsCh
+	return result, nil
 }

--- a/internal/lang/js/streaming.go
+++ b/internal/lang/js/streaming.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	"prune/internal/config"
 	"prune/internal/rules"
 	"prune/internal/scan"
@@ -18,20 +19,20 @@ func AnalyzeStreaming(ctx context.Context, cfg *config.Config, handler StreamHan
 	}
 
 	stream := cfg.Scan.Stream
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
 	entries, err := scan.CollectWithContext(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	collector := NewCollector(cfg)
-	var lastCollected *Collected
-	emitted := map[string]bool{}
-
 	entriesCh := make(chan []scan.FileEntry, 1)
-	errCh := make(chan error, 1)
+	resultsCh := make(chan []rules.Finding, 1)
 
-	go func() {
+	group, groupCtx := errgroup.WithContext(ctx)
+
+	group.Go(func() error {
 		defer close(entriesCh)
 		batch := []scan.FileEntry{}
 		lastEmit := time.Now()
@@ -39,9 +40,8 @@ func AnalyzeStreaming(ctx context.Context, cfg *config.Config, handler StreamHan
 
 		for _, entry := range entries {
 			select {
-			case <-ctx.Done():
-				errCh <- ctx.Err()
-				return
+			case <-groupCtx.Done():
+				return groupCtx.Err()
 			default:
 			}
 
@@ -52,53 +52,80 @@ func AnalyzeStreaming(ctx context.Context, cfg *config.Config, handler StreamHan
 				batchSize = stream.BatchSize
 			}
 			if len(batch) >= batchSize || time.Since(lastEmit) >= interval {
-				entriesCh <- batch
+				select {
+				case <-groupCtx.Done():
+					return groupCtx.Err()
+				case entriesCh <- batch:
+				}
 				batch = []scan.FileEntry{}
 				lastEmit = time.Now()
 			}
 		}
 
 		if len(batch) > 0 {
-			entriesCh <- batch
-		}
-	}()
-
-	processed := 0
-	for batch := range entriesCh {
-		select {
-		case err := <-errCh:
-			return nil, err
-		default:
+			select {
+			case <-groupCtx.Done():
+				return groupCtx.Err()
+			case entriesCh <- batch:
+			}
 		}
 
-		collected, err := collector.Collect(ctx, batch)
-		if err != nil {
-			return nil, err
-		}
-		lastCollected = collected
-		findings := applyRules(cfg, collected)
-		processed += len(batch)
+		return nil
+	})
 
-		if stream.Enabled && stream.IntervalMs > 0 && handler != nil {
-			newFindings := make([]rules.Finding, 0, len(findings))
-			for _, finding := range findings {
-				if emitted[finding.ID] {
-					continue
+	group.Go(func() error {
+		collector := NewCollector(cfg)
+		var lastCollected *Collected
+		emitted := map[string]bool{}
+
+		for {
+			select {
+			case <-groupCtx.Done():
+				return groupCtx.Err()
+			case batch, ok := <-entriesCh:
+				if !ok {
+					if lastCollected == nil {
+						resultsCh <- nil
+						return nil
+					}
+					resultsCh <- applyRules(cfg, lastCollected)
+					return nil
 				}
-				emitted[finding.ID] = true
-				newFindings = append(newFindings, finding)
-			}
-			if len(newFindings) == 0 {
-				continue
-			}
-			if err := handler(newFindings); err != nil {
-				return nil, err
+				collected, err := collector.Collect(groupCtx, batch)
+				if err != nil {
+					return err
+				}
+				lastCollected = collected
+				findings := applyRules(cfg, collected)
+
+				if stream.Enabled && stream.IntervalMs > 0 && handler != nil {
+					newFindings := make([]rules.Finding, 0, len(findings))
+					for _, finding := range findings {
+						if emitted[finding.ID] {
+							continue
+						}
+						emitted[finding.ID] = true
+						newFindings = append(newFindings, finding)
+					}
+					if len(newFindings) == 0 {
+						continue
+					}
+					if err := handler(newFindings); err != nil {
+						return err
+					}
+				}
 			}
 		}
+	})
+
+	if err := group.Wait(); err != nil {
+		return nil, err
 	}
 
-	if lastCollected == nil {
+	select {
+	case result := <-resultsCh:
+		return result, nil
+	default:
 		return nil, nil
 	}
-	return applyRules(cfg, lastCollected), nil
 }

--- a/internal/lang/js/streaming_cancel_test.go
+++ b/internal/lang/js/streaming_cancel_test.go
@@ -1,0 +1,73 @@
+package js
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"prune/internal/config"
+	"prune/internal/rules"
+)
+
+func TestAnalyzeStreamingCancelsOnHandlerError(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	cfg := &config.Config{Version: 1}
+	cfg.Scan.Paths = []string{filepath.Join(root, "internal", "cli", "testdata", "streaming", "src")}
+	cfg.Scan.Include = []string{"**/*.ts"}
+	cfg.Scan.Stream.Enabled = true
+	cfg.Scan.Stream.IntervalMs = 1
+	cfg.Scan.Stream.BatchSize = 1
+	cfg.Entrypoints.Files = []string{
+		filepath.ToSlash(cfg.Scan.Paths[0]) + "/index.ts",
+	}
+
+	start := time.Now()
+	want := errors.New("handler failed")
+	_, err = AnalyzeStreaming(context.Background(), cfg, func(batch []rules.Finding) error {
+		return want
+	})
+	if err == nil {
+		t.Fatalf("expected handler error")
+	}
+	if !errors.Is(err, want) {
+		t.Fatalf("expected handler error, got %v", err)
+	}
+	if time.Since(start) > 2*time.Second {
+		t.Fatalf("expected AnalyzeStreaming to return promptly")
+	}
+}
+
+func TestAnalyzeStreamingHonorsContextCancel(t *testing.T) {
+	root, err := repoRoot()
+	if err != nil {
+		t.Fatalf("resolve repo root: %v", err)
+	}
+
+	cfg := &config.Config{Version: 1}
+	cfg.Scan.Paths = []string{filepath.Join(root, "internal", "cli", "testdata", "streaming", "src")}
+	cfg.Scan.Include = []string{"**/*.ts"}
+	cfg.Scan.Stream.Enabled = true
+	cfg.Scan.Stream.IntervalMs = 1
+	cfg.Scan.Stream.BatchSize = 1
+	cfg.Entrypoints.Files = []string{
+		filepath.ToSlash(cfg.Scan.Paths[0]) + "/index.ts",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = AnalyzeStreaming(ctx, cfg, func(batch []rules.Finding) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatalf("expected context cancellation error")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- coordinate streaming producer/consumer with errgroup and cancellation
- prevent blocked sends and ensure early returns cancel the producer
- add tests for handler error cancellation and context cancellation

## Testing
- go test ./internal/lang/js -run TestAnalyzeStreaming
- make test

Closes #61 