### PR TITLE
Fix streaming interval check

### DIFF
--- a/internal/scan/streaming.go
+++ b/internal/scan/streaming.go
@@ -38,7 +38,7 @@ func (s *StreamingProcessor) ShouldEmit() bool {
 		return false
 	}
 	elapsed := time.Since(s.lastEmit)
-	return elapsed >= time.Duration(s.cfg.IntervalMs)*time.Millisecond
+	return elapsed >= time.Duration(s.interval)*time.Millisecond
 }
 
 func (s *StreamingProcessor) EmitBatch(entries []FileEntry) error {

--- a/internal/scan/streaming_test.go
+++ b/internal/scan/streaming_test.go
@@ -1,0 +1,31 @@
+package scan
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStreamingProcessorShouldEmitUsesDefaultInterval(t *testing.T) {
+	proc := NewStreamingProcessor(&StreamConfig{Enabled: true}, nil)
+	if proc.ShouldEmit() {
+		t.Fatalf("expected ShouldEmit to be false immediately")
+	}
+
+	proc.lastEmit = time.Now().Add(-251 * time.Millisecond)
+	if !proc.ShouldEmit() {
+		t.Fatalf("expected ShouldEmit to be true after default interval")
+	}
+}
+
+func TestStreamingProcessorShouldEmitUsesConfiguredInterval(t *testing.T) {
+	proc := NewStreamingProcessor(&StreamConfig{Enabled: true, IntervalMs: 10}, nil)
+	proc.lastEmit = time.Now().Add(-5 * time.Millisecond)
+	if proc.ShouldEmit() {
+		t.Fatalf("expected ShouldEmit to be false before configured interval")
+	}
+
+	proc.lastEmit = time.Now().Add(-11 * time.Millisecond)
+	if !proc.ShouldEmit() {
+		t.Fatalf("expected ShouldEmit to be true after configured interval")
+	}
+}


### PR DESCRIPTION
## Summary
- use the computed streaming interval when deciding to emit batches
- add unit tests for default and configured interval behavior

## Testing
- go test ./internal/scan -run TestStreamingProcessorShouldEmit
- make test